### PR TITLE
fix: 使机器人管理员组的权限凌驾于群管理员

### DIFF
--- a/src/event/handler/base.ts
+++ b/src/event/handler/base.ts
@@ -102,8 +102,8 @@ export class EventBaseHandler {
 
       const role = list[permission]
       if (!role) return true
-      if (role.role === 'owner' && this.e.sender?.role === 'owner') return true
-      if (role.role === 'admin' && (this.e.sender?.role === 'owner' || this.e.sender?.role === 'admin')) return true
+      if (role.role === 'owner' && (this.e.sender?.role === 'owner' || this.e.isMaster || this.e.isAdmin)) return true
+      if (role.role === 'admin' && (this.e.sender?.role === 'owner' || this.e.sender?.role === 'admin' || this.e.isMaster || this.e.isAdmin)) return true
 
       this.e.reply(`暂无权限，只有${role.name}才能操作`)
       return false


### PR DESCRIPTION
方便群管类插件分配权限，更加符合日常使用场景