### PR TITLE
fix: [onebot11]群临时消息

### DIFF
--- a/src/adapter/onebot/11/event.ts
+++ b/src/adapter/onebot/11/event.ts
@@ -52,7 +52,7 @@ export class OB11Event {
     const message = {
       event: EventType.Message as EventType.Message,
       event_id: data.message_id + '',
-      sub_event: data.sub_type === 'friend' ? MessageSubType.PrivateMessage : MessageSubType.GroupMessage,
+      sub_event: data.message_type === 'private' ? MessageSubType.PrivateMessage : MessageSubType.GroupMessage,
       raw_event: data,
       self_id: data.self_id + '',
       user_id: data.sender.user_id + '',


### PR DESCRIPTION
根据onebot11标准，私聊的sub_type为'friend'/‘group’/'other'，群消息的sub_type为'normal'/'anonymous'/'notice'
回复群临时消息疑似还与风控因素有关。在测试中，本次修复后，框架正确地处理了群临时消息，但适配器依旧无法发送回复。测试使用Lagrange.OneBot作为适配器

## Summary by Sourcery

错误修复：
- 修正 OneBot11 事件的 sub_event 分配逻辑，以正确区分私人消息和群组消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the sub_event assignment logic for OneBot11 events to properly distinguish between private and group messages.

</details>