### PR TITLE
fix: 链接本地安装

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "typescript": "^5.5.4"
   },
   "peerDependencies": {
-    "node-karin": "link:./lib"
+    "node-karin": "link:."
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修复在 peerDependencies 中 'node-karin' 包的本地链接以指向正确的目录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the local linking of the 'node-karin' package in peerDependencies to point to the correct directory.

</details>