### PR TITLE
fix: close #385

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "bin": {
-    "ki": "karin.js",
+    "ki": "index.js",
     "karin": "index.js"
   },
   "engines": {


### PR DESCRIPTION
## Sourcery 总结

Bug 修复：
- 修正了 `ki` 命令的二进制入口点，从 'karin.js' 改为 'index.js'

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Corrected the binary entry point from 'karin.js' to 'index.js' for the 'ki' command

</details>