### PR TITLE
refactor: 重构`getHistoryMsg`接口 支持传入`seq`

### DIFF
--- a/packages/core/src/adapter/base/index.ts
+++ b/packages/core/src/adapter/base/index.ts
@@ -147,7 +147,25 @@ export abstract class AdapterBase<T = any> implements AdapterType<T> {
    * @param _count 获取消息数量 默认为1
    * @returns 包含历史消息的数组
    */
-  getHistoryMsg (_contact: Contact, _startMsgId: string, _count: number): Promise<Array<MessageResponse>> {
+  getHistoryMsg (_contact: Contact, _startMsgId: string, _count: number): Promise<Array<MessageResponse>>
+
+  /**
+   * 获取msgSeq获取历史消息
+   * @param _contact 目标信息
+   * @param _startMsgSeq 起始消息序列号
+   * @param _count 获取消息数量 默认为1
+   * @returns 包含历史消息的数组
+   */
+  getHistoryMsg (_contact: Contact, _startMsgSeq: number, _count: number): Promise<Array<MessageResponse>>
+
+  /**
+   * 获取msgId获取历史消息
+   * @param _contact 目标信息
+   * @param _startMsgId 起始消息ID
+   * @param _count 获取消息数量 默认为1
+   * @returns 包含历史消息的数组
+   */
+  getHistoryMsg (_contact: Contact, _startMsgId: string | number, _count: number): Promise<Array<MessageResponse>> {
     throw new Error(`[adapter][${this.adapter.protocol}] 此接口未实现`)
   }
 

--- a/packages/core/src/adapter/onebot/core/base.ts
+++ b/packages/core/src/adapter/onebot/core/base.ts
@@ -284,7 +284,7 @@ export abstract class AdapterOneBot extends AdapterBase {
    * @param messageId 消息ID
    */
   async getMsg (contact: Contact, messageId: string) {
-    const result = await this.sendApi(OB11ApiAction.getMsg, { message_id: Number(messageId) ?? messageId as unknown as number })
+    const result = await this.sendApi(OB11ApiAction.getMsg, { message_id: Number(messageId) || messageId as unknown as number })
     const userId = result.sender.user_id + ''
     const messageSeq = result.message_seq || result.message_id
     const messageID = result.message_id + ''

--- a/packages/core/src/types/adapter/class.ts
+++ b/packages/core/src/types/adapter/class.ts
@@ -117,6 +117,15 @@ export interface AdapterType<T = any> {
   /**
    * 获取msgId获取历史消息
    * @param contact 目标信息
+   * @param startMsgSeq 起始消息序列号
+   * @param count 获取消息数量 默认为1
+   * @returns 包含历史消息的数组
+   */
+  getHistoryMsg (contact: Contact, startMsgSeq: number, count: number): Promise<Array<MessageResponse>>
+
+  /**
+   * 获取msgId获取历史消息
+   * @param contact 目标信息
    * @param startMsgId 起始消息ID
    * @param count 获取消息数量 默认为1
    * @returns 包含历史消息的数组


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构 `getHistoryMsg` 接口，以支持使用消息 ID 和消息序列号检索消息历史记录

增强功能：
- 通过支持多种输入类型，提高了消息历史记录检索的灵活性
- 增加了使用序列号检索消息的支持
- 增强了与不同 OneBot 适配器的兼容性

杂项：
- 更新了 `getHistoryMsg` 方法的类型定义
- 重构了实现以处理不同的消息检索场景

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the `getHistoryMsg` interface to support retrieving message history using both message ID and message sequence number

Enhancements:
- Improved flexibility of message history retrieval by supporting multiple input types
- Added support for retrieving messages using sequence number
- Enhanced compatibility with different OneBot adapters

Chores:
- Updated type definitions for the `getHistoryMsg` method
- Refactored implementation to handle different message retrieval scenarios

</details>