### PR TITLE
fix: close #372

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -174,7 +174,7 @@
   "devDependencies": {
     "@karinjs/node-pty": "^1.1.0",
     "@karinjs/plugin-webui-network-monitor": "^1.0.3",
-    "@karinjs/plugins-list": "^1.6.1",
+    "@karinjs/plugins-list": "^1.7.0",
     "@types/express": "^5.0.1",
     "@types/lodash": "^4.17.16",
     "cross-env": "^7.0.3",

--- a/packages/core/src/env/env/index.ts
+++ b/packages/core/src/env/env/index.ts
@@ -1,5 +1,8 @@
 import fs from 'node:fs'
 import yaml from 'yaml'
+import { execSync } from 'node:child_process'
+
+let IS_PNPM10: boolean | null = null
 
 /**
  * @description 是否为Windows
@@ -45,6 +48,23 @@ export const isTs = () => isTsx()
  * @description 是否为生产环境
  */
 export const isProd = () => !isDev()
+
+/**
+ * @description 是否为pnpm
+ */
+export const isPnpm10 = () => {
+  try {
+    if (IS_PNPM10 === null) {
+      const version = execSync('pnpm -v').toString()
+      IS_PNPM10 = version.includes('10')
+    }
+
+    return IS_PNPM10
+  } catch {
+    IS_PNPM10 = false
+    return false
+  }
+}
 
 /**
  * @description 当前环境是否为pnpm工作区

--- a/packages/core/src/env/env/index.ts
+++ b/packages/core/src/env/env/index.ts
@@ -50,13 +50,14 @@ export const isTs = () => isTsx()
 export const isProd = () => !isDev()
 
 /**
- * @description 是否为pnpm
+ * @description 是否>= pnpm10
  */
 export const isPnpm10 = () => {
   try {
     if (IS_PNPM10 === null) {
-      const version = execSync('pnpm -v').toString()
-      IS_PNPM10 = version.includes('10')
+      const version = execSync('pnpm -v').toString().trim()
+      const majorVersion = parseInt(version.split('.')[0], 10)
+      IS_PNPM10 = !isNaN(majorVersion) && majorVersion >= 10
     }
 
     return IS_PNPM10

--- a/packages/core/src/server/plugins/admin/installCustom.ts
+++ b/packages/core/src/server/plugins/admin/installCustom.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import { AxiosError } from 'axios'
-import { isWorkspace } from '@/env'
+import { isPnpm10, isWorkspace } from '@/env'
 import { handleReturn, spawnProcess } from './tool'
 import { karinPathPlugins } from '@/root'
 import { mkdirSync } from '@/utils/fs/fsSync'
@@ -67,6 +67,9 @@ const installNpm = async (
       const args = ['add', pkg, '--save']
       if (isWorkspace()) args.push('-w')
       if (data.registry) args.push(`--registry=${data.registry}`)
+      if (Array.isArray(data.allowBuild) && data.allowBuild.length && isPnpm10()) {
+        data.allowBuild.forEach(pkg => args.unshift(`--allow-build=${pkg}`))
+      }
 
       /** 处理 ERR_PNPM_PUBLIC_HOIST_PATTERN_DIFF 错误 */
       let IS_ERR_PNPM_PUBLIC_HOIST_PATTERN_DIFF = false

--- a/packages/core/src/types/dependencies/index.ts
+++ b/packages/core/src/types/dependencies/index.ts
@@ -17,6 +17,8 @@ export interface AddDependenciesParams extends DependenciesManageBase {
     location: 'dependencies' | 'devDependencies' | 'optionalDependencies'
     /** 依赖版本 */
     version?: string
+    /** 允许pnpm在安装期间执行安装的包名列表 */
+    allowBuild?: string[]
   }
 }
 

--- a/packages/core/src/types/task/plugin.ts
+++ b/packages/core/src/types/task/plugin.ts
@@ -36,6 +36,8 @@ interface PluginAdminCustomInstallNpm extends PluginAdminCustomInstallBase {
   version?: string
   /** 指定registry源 */
   registry?: string
+  /** 允许pnpm在安装期间执行安装的包名列表 */
+  allowBuild?: string[]
 }
 
 /**
@@ -155,6 +157,8 @@ export interface PluginAdminMarketInstallApp extends PluginAdminMarketInstallBaa
  */
 interface PluginAdminMarketInstallNpm extends PluginAdminMarketInstallBaase {
   pluginType: 'npm'
+  /** 允许pnpm在安装期间执行脚本的包名列表 */
+  allowBuild?: string[]
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,8 +110,8 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       '@karinjs/plugins-list':
-        specifier: ^1.6.1
-        version: 1.6.1
+        specifier: ^1.7.0
+        version: 1.7.0
       '@types/express':
         specifier: ^5.0.1
         version: 5.0.1
@@ -1892,8 +1892,8 @@ packages:
   '@karinjs/plugin-webui-network-monitor@1.0.3':
     resolution: {integrity: sha512-FloMaA3/41ZWOy0oVReH2tvS3FUABgzj2+EZ/6f7FkyC1aK4sQYsEDRuB2ru8RC7uycRxU2E0Tufj3jtnU5AGA==}
 
-  '@karinjs/plugins-list@1.6.1':
-    resolution: {integrity: sha512-yOMcsGDaPiLpwImxzU5+2tAUBAaik0eFezNEzxxWqPHw685DHFZFe6sD5NewT2UkKJPivqX0SrEshJb5U56GPg==}
+  '@karinjs/plugins-list@1.7.0':
+    resolution: {integrity: sha512-5LE4jfrEvel80cczxwoL0yOkWIJsk/0D5pThXzgm8L6VGHXC1woJnxrGRUPAZ5hYLSR/zkg/av17aq5NpMc9Mw==}
 
   '@karinjs/redis@1.1.3':
     resolution: {integrity: sha512-Keo+1pJxvddTqBF4BE7AnZqvbBRXZ4QaZa8uJCKngmQ303TV3M0x0gHuKBfDNXQAkiHylw09a3YAzj68sh/Dhw==}
@@ -7578,7 +7578,7 @@ snapshots:
     dependencies:
       systeminformation: 5.25.11
 
-  '@karinjs/plugins-list@1.6.1': {}
+  '@karinjs/plugins-list@1.7.0': {}
 
   '@karinjs/redis@1.1.3': {}
 


### PR DESCRIPTION
好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

在 pnpm 10 中添加对允许在依赖安装期间构建特定包的支持

新特性：
- 引入了指定允许在依赖安装期间运行构建脚本的包的功能
- 在依赖安装模态框中添加了对管理允许构建的包的 UI 支持

增强：
- 增加了对 pnpm 10 版本的检测
- 更新了依赖安装工作流程以支持 pnpm 10 构建允许列表

杂项：
- 更新了包依赖
- 扩展了类型定义以支持新的构建允许列表功能

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for allowing specific packages to be built during dependency installation in pnpm 10

New Features:
- Introduce ability to specify packages allowed to run build scripts during dependency installation
- Add UI support for managing allowed build packages in dependency installation modal

Enhancements:
- Add detection for pnpm 10 version
- Update dependency installation workflows to support pnpm 10 build allowlist

Chores:
- Update package dependencies
- Extend type definitions to support new build allowlist feature

</details>