### PR TITLE
fix: close #392

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -23,25 +23,12 @@ const checkKarinDependency = () => {
 /**
  * 检查 CLI 入口文件是否存在
  */
-const checkCliExists = () => {
-  const cjsPath = join(process.cwd(), 'node_modules/node-karin/dist/cli/index.cjs')
-  const mjsPath = join(process.cwd(), 'node_modules/node-karin/dist/cli/index.mjs')
-  return existsSync(cjsPath) || existsSync(mjsPath)
-}
-
-/**
- * 获取可用的 CLI 路径
- */
-const getCliPath = () => {
-  const cjsPath = join(process.cwd(), 'node_modules/node-karin/dist/cli/index.cjs')
-  const mjsPath = join(process.cwd(), 'node_modules/node-karin/dist/cli/index.mjs')
-
-  if (existsSync(cjsPath)) {
-    return cjsPath
-  } else if (existsSync(mjsPath)) {
-    return mjsPath
-  }
-  return null
+const getValidCliPath = () => {
+  const cliPaths = [
+    join(process.cwd(), 'node_modules/node-karin/dist/cli/index.cjs'),
+    join(process.cwd(), 'node_modules/node-karin/dist/cli/index.mjs'),
+  ]
+  return cliPaths.find(path => existsSync(path)) || null
 }
 
 try {
@@ -60,16 +47,9 @@ try {
   }
 
   // 检查 CLI 文件是否存在
-  const cliExists = checkCliExists()
-  if (!cliExists) {
-    console.error('错误: node-karin CLI 文件不存在，请升级 node-karin 依赖版本')
-    process.exit(1)
-  }
-
-  // 执行 node-karin CLI
-  const cliPath = getCliPath()
+  const cliPath = getValidCliPath()
   if (!cliPath) {
-    console.error('错误: 无法找到有效的 CLI 入口文件')
+    console.error('错误: node-karin CLI 文件不存在，请升级 node-karin 依赖版本')
     process.exit(1)
   }
 

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -24,8 +24,24 @@ const checkKarinDependency = () => {
  * 检查 CLI 入口文件是否存在
  */
 const checkCliExists = () => {
-  const cliPath = join(process.cwd(), 'index.mjs')
-  return existsSync(cliPath)
+  const cjsPath = join(process.cwd(), 'node_modules/node-karin/dist/cli/index.cjs')
+  const mjsPath = join(process.cwd(), 'node_modules/node-karin/dist/cli/index.mjs')
+  return existsSync(cjsPath) || existsSync(mjsPath)
+}
+
+/**
+ * 获取可用的 CLI 路径
+ */
+const getCliPath = () => {
+  const cjsPath = join(process.cwd(), 'node_modules/node-karin/dist/cli/index.cjs')
+  const mjsPath = join(process.cwd(), 'node_modules/node-karin/dist/cli/index.mjs')
+
+  if (existsSync(cjsPath)) {
+    return cjsPath
+  } else if (existsSync(mjsPath)) {
+    return mjsPath
+  }
+  return null
 }
 
 try {
@@ -51,7 +67,12 @@ try {
   }
 
   // 执行 node-karin CLI
-  const cliPath = join(process.cwd(), 'index.mjs')
+  const cliPath = getCliPath()
+  if (!cliPath) {
+    console.error('错误: 无法找到有效的 CLI 入口文件')
+    process.exit(1)
+  }
+
   import(`file://${cliPath}`)
 } catch (error) {
   console.error('执行出错:', error)


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

改进 node-karin 的 CLI 入口点检测，支持多种文件格式并提供更好的错误处理

Bug 修复：
- 增加对 .cjs 和 .mjs CLI 入口点文件的支持
- 实施强大的 CLI 文件路径检测机制

增强功能：
- 创建一个新函数来获取可用的 CLI 路径
- 改进未找到有效 CLI 入口时的错误消息

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve CLI entry point detection for node-karin by supporting multiple file formats and providing better error handling

Bug Fixes:
- Add support for both .cjs and .mjs CLI entry point files
- Implement robust CLI file path detection mechanism

Enhancements:
- Create a new function to get the available CLI path
- Improve error messaging when no valid CLI entry is found

</details>