### PR TITLE
refactor(core): 优化插件目录创建逻辑

### DIFF
--- a/packages/core/src/plugin/admin/load.ts
+++ b/packages/core/src/plugin/admin/load.ts
@@ -56,7 +56,7 @@ export const pkgLoads = async (
   }
 
   /** 创建插件基本文件夹 - 这个需要立即执行 */
-  await createPluginDir(pkg.name.replace(/\//g, '-'), files)
+  await createPluginDir(pkg.name, files)
   debug('debug: createPluginDir', pkg.name, files)
 
   /** 收集所有app加载的Promise */


### PR DESCRIPTION
- 修改 createPluginDir 函数，以支持组织包的兼容性
- 对于以 @ 开头的组织包，优先使用旧版兼容格式 (@org-pkg-name)
- 如果旧版格式不存在，则创建新版组织包结构 (@org/pkg-name)
- 更新相关类型定义，提高代码可读性和安全性

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构插件目录创建，以增强与组织包的兼容性并改进类型定义。

增强功能：
- 改进插件目录创建逻辑，以支持旧版和新的组织包格式。
- 更新类型定义，以提高代码可读性和类型安全性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor plugin directory creation to enhance compatibility with organization packages and improve type definitions.

Enhancements:
- Improve plugin directory creation logic to support both legacy and new organization package formats.
- Update type definitions for better code readability and type safety.

</details>