### PR TITLE
build(docker): 修复docker容器镜像无法启动

### DIFF
--- a/packages/docker/Dockerfile
+++ b/packages/docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:lts-slim
 
+# 设置工作目录
+WORKDIR /app
+
 # 安装pnpm和karin cli工具
 RUN npm install -g pnpm@^9 @karinjs/cli
 
@@ -9,8 +12,6 @@ RUN pnpm init && \
   npx karin init && \
   pnpm add @karinjs/plugin-puppeteer -w
 
-# 设置工作目录
-WORKDIR /app
 
 # 安装精简的运行时依赖
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/packages/docker/start.sh
+++ b/packages/docker/start.sh
@@ -3,4 +3,5 @@
 export HTTP_PORT=${PORT:-7777}
 
 # 启动应用
+cd /app
 exec pnpm app


### PR DESCRIPTION
好的，这是翻译成中文的pull request总结：

## Sourcery 总结

修复 Docker 容器启动问题，确保在 Dockerfile 和启动脚本中正确设置工作目录。

Bug 修复:
- 将 `WORKDIR` 指令移至 Dockerfile 的顶部，并删除重复的声明。
- 在 `start.sh` 中添加 `cd /app` 命令，以便应用程序从正确的目录运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Docker container startup by ensuring the working directory is correctly set in both the Dockerfile and the startup script.

Bug Fixes:
- Move the WORKDIR directive to the top of the Dockerfile and remove its duplicate declaration.
- Add a cd /app command in start.sh so the application runs from the correct directory.

</details>