### PR TITLE
refactor: onebot adapter

### DIFF
--- a/packages/plugin-adapter-onebot/package.json
+++ b/packages/plugin-adapter-onebot/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "plugin-adapter-onebot",
+  "version": "1.0.0",
+  "author": "shijin",
+  "type": "module",
+  "description": "karin plugin template",
+  "homepage": "https://github.com/KarinJS/karin",
+  "bugs": {
+    "url": "https://github.com/KarinJS/karin/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KarinJS/karin.git"
+  },
+  "scripts": {
+    "app": "node lib/app.js",
+    "build": "tsup",
+    "dev": "cross-env EBV_FILE=\"development.env\" node --import tsx src/app.ts",
+    "pub": "npm publish --access public"
+  },
+  "main": "lib/index.js",
+  "devDependencies": {
+    "@types/express": "^5.0.1",
+    "@types/lodash": "^4.17.16",
+    "@types/node": "^20.17.8",
+    "cross-env": "^7.0.3",
+    "eslint": "^9.7.0",
+    "neostandard": "^0.11.9",
+    "node-karin": "*",
+    "tsup": "^8.5.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.5.3"
+  },
+  "karin": {
+    "main": "src/index.ts",
+    "apps": [
+      "lib/apps"
+    ],
+    "ts-apps": [
+      "src/apps"
+    ],
+    "static": [
+      "resources"
+    ],
+    "files": [
+      "config",
+      "data",
+      "resources"
+    ]
+  },
+  "files": [
+    "/lib/**/*.js",
+    "/lib/**/*.d.ts",
+    "/config/*.json",
+    "resources",
+    "!lib/app.js"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  }
+}

--- a/packages/plugin-adapter-onebot/tsconfig.json
+++ b/packages/plugin-adapter-onebot/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "module": "ES2022",
+    "target": "ES2022",
+    "esModuleInterop": true,
+    "moduleResolution": "Bundler",
+    "outDir": "./lib",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "src/*"
+      ],
+    },
+    "rootDir": "./src",
+    "declaration": true,
+    "noImplicitAny": true,
+    "strict": true
+  },
+  "include": [
+    "src/**/*",
+  ],
+  "exclude": [
+    "node_modules",
+  ]
+}

--- a/packages/plugin-adapter-onebot/tsup.config.ts
+++ b/packages/plugin-adapter-onebot/tsup.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'tsup'
+import type { Options } from 'tsup'
+
+/**
+ * @description `tsup` configuration options
+ */
+export const options: Options = {
+  entry: ['src/*.ts', 'src/apps/*.ts'], // 入口文件
+  format: ['esm'], // 输出格式
+  target: 'node18', // 目标环境
+  splitting: true, // 是否拆分文件 启用哦 不然会强制打包的~
+  sourcemap: false, // 是否生成 sourcemap
+  clean: true, // 是否清理输出目录
+  dts: false, // 是否生成 .d.ts 文件 没啥事可以不需要生成类型，除非你的插件会被其他插件调用。
+  outDir: 'lib', // 输出目录
+  treeshake: false, // 树摇优化
+  minify: false, // 压缩代码
+  external: [
+    'node-karin',
+  ],
+  shims: true,
+}
+
+export default defineConfig(options)


### PR DESCRIPTION
本PR将把`OneBot`适配器进行分离 分离为单独的模块  
依旧保留配置文件位置

- [ ] 支持所有 `go-cqhttp` Api`(频道不支持)`
- [ ] 支持所有 `go-cqhttp` 上报事件
- [ ] 支持所有 `NapCat` Api
- [ ] 支持所有 `NapCat` 上报事件
- [ ] 支持所有 `Lagrange.OneBot` Api
- [ ] 支持所有 `Lagrange.OneBot` 上报事件

如果有时间，将一并支持`OneBot v12`

- [ ] v12主要以支持 [ComWeChatBotClient](https://justundertaker.github.io/ComWeChatBotClient/) 为目标

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

将 OneBot 适配器分离成一个独立的 `plugin-adapter-onebot` 包，并包含初始配置和构建设置

增强功能：
- 将 OneBot 适配器提取到其自身的包模块中

构建：
- 为新的适配器添加包含项目元数据和脚本的 package.json
- 为适配器包引入 TypeScript 配置 (tsconfig.json)
- 添加 tsup 配置 (tsup.config.ts) 以定义构建输出和打包选项

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Separate the OneBot adapter into a standalone `plugin-adapter-onebot` package with initial configuration and build setup

Enhancements:
- Extract the OneBot adapter into its own package module

Build:
- Add package.json with project metadata and scripts for the new adapter
- Introduce TypeScript configuration (tsconfig.json) for the adapter package
- Add tsup configuration (tsup.config.ts) to define build output and bundling options

</details>