### PR TITLE
refactor: 重构插件索引页

### DIFF
--- a/packages/core/src/env/env/index.ts
+++ b/packages/core/src/env/env/index.ts
@@ -37,11 +37,11 @@ export const isTsx = () => process.env.RUNTIME === 'tsx'
  */
 export const isPm2 = () => process.env.RUNTIME === 'pm2'
 /**
- * @description 是否为Js
+ * @description 是否只允许运行js
  */
 export const isJs = () => !isTsx()
 /**
- * @description 是否为Ts
+ * @description 是否允许直接运行Ts
  */
 export const isTs = () => isTsx()
 /**

--- a/packages/core/src/env/key/redis.ts
+++ b/packages/core/src/env/key/redis.ts
@@ -1,11 +1,19 @@
-/** redis: 插件列表缓存键名 */
+/** redis: 插件市场缓存键名 */
 export const REDIS_PLUGIN_LIST_CACHE_KEY = 'karin:market:plugin:list'
 /** redis: 依赖列表缓存键名 */
 export const REDIS_DEPENDENCIES_LIST_CACHE_KEY = 'karin:dependencies:list'
-
-/** redis: 依赖列表缓存过期时间 3小时 */
-export const REDIS_DEPENDENCIES_LIST_CACHE_EXPIRE = 3 * 60 * 60
 /** redis: 插件市场列表缓存键名 */
 export const REDIS_PLUGIN_MARKET_LIST_CACHE_KEY = 'karin:market:plugin:list:v2'
-/** redis: 插件市场列表缓存过期时间 12小时 */
-export const REDIS_PLUGIN_MARKET_LIST_CACHE_EXPIRE = 12 * 60 * 60
+/** redis: 本地插件列表缓存键名 */
+export const REDIS_LOCAL_PLUGIN_LIST_CACHE_KEY = 'karin:local:plugin:list'
+/** redis: 本地插件列表缓存键名 用于前端显示插件简约列表  */
+export const REDIS_LOCAL_PLUGIN_LIST_CACHE_KEY_FRONTEND = 'karin:local:plugin:list:frontend'
+
+/** redis: 依赖列表缓存过期时间 24小时 */
+export const REDIS_DEPENDENCIES_LIST_CACHE_EXPIRE = 24 * 60 * 60
+/** redis: 插件市场列表缓存过期时间 24小时 */
+export const REDIS_PLUGIN_MARKET_LIST_CACHE_EXPIRE = 24 * 60 * 60
+/** redis: 本地插件列表缓存过期时间 24小时 */
+export const REDIS_PLUGIN_LIST_CACHE_EXPIRE = 24 * 60 * 60
+/** redis: 本地插件列表缓存过期时间 24小时 用于前端显示插件简约列表 */
+export const REDIS_LOCAL_PLUGIN_LIST_CACHE_EXPIRE_FRONTEND = 24 * 60 * 60

--- a/packages/core/src/server/dependencies/list.ts
+++ b/packages/core/src/server/dependencies/list.ts
@@ -110,7 +110,8 @@ const getDependenciesInfo = async (
 
   try {
     /** 获取版本列表 */
-    const versions = await getNpmRegistry(value.from)
+    const registry = await getNpmRegistry(value.from)
+    const versions = Object.keys(registry.versions)
 
     /** 获取最新的15个版本 数组最后就是最新的版本 不足15个就返回全部 */
     const latest = versions.slice(-15).filter(Boolean)

--- a/packages/core/src/server/plugins/config.ts
+++ b/packages/core/src/server/plugins/config.ts
@@ -268,6 +268,10 @@ export const pluginGetConfig: RequestHandler = async (req, res) => {
     return createServerErrorResponse(res, '参数错误')
   }
 
+  if (typeof config.components !== 'function') {
+    return createServerErrorResponse(res, '该插件未提供默认组件配置函数')
+  }
+
   const list: Record<string, any>[] = []
   let result = config.components()
   result = util.types.isPromise(result) ? await result : result
@@ -303,6 +307,9 @@ export const pluginSaveConfig: RequestHandler = async (req, res) => {
   if (!configPath) return createServerErrorResponse(res, '参数错误')
 
   const { save } = await loadConfig(configPath)
+  if (typeof save !== 'function') {
+    return createServerErrorResponse(res, '该插件未提供默认组件保存完成')
+  }
   const result = save(options.config)
   const response = util.types.isPromise(result) ? await result : result
   createSuccessResponse(res, response || { success: true, message: '没有返回值哦 φ(>ω<*) ' })

--- a/packages/core/src/server/plugins/config/webConfig.ts
+++ b/packages/core/src/server/plugins/config/webConfig.ts
@@ -67,12 +67,12 @@ const getWebConfigPath = (plugin: PkgInfo) => {
  */
 const getWebConfigMore = async (filepath: string) => {
   try {
-    const web = await imports(`file://${filepath}`, { isImportDefault: true, isRefresh: isDev() })
+    const web = await imports(filepath, { isImportDefault: true, isRefresh: isDev() })
     return defaultWebConfig(
       true,
       filepath,
       typeof web?.customComponent === 'function',
-      typeof web?.defaultComponent === 'function'
+      typeof web?.components === 'function'
     )
   } catch (error) {
     logger.error(new Error('获取插件web.config文件失败', { cause: error }))

--- a/packages/core/src/server/plugins/config/webConfig.ts
+++ b/packages/core/src/server/plugins/config/webConfig.ts
@@ -1,0 +1,81 @@
+import fs from 'fs'
+import path from 'path'
+import { isDev } from '@/env'
+import { imports } from '@/utils'
+import { getPlugins } from '@/plugin/system/list'
+import type { PkgInfo, PluginAdminListResponse } from '@/types'
+
+/**
+ * 传入插件名称 获取插件的web配置
+ * @param name 插件名称
+ */
+export const getWebConfig = async (name: string): Promise<PluginAdminListResponse['webConfig']> => {
+  const list = await getPlugins('all', true)
+  const plugin = list.find(v => v.name === name)
+  if (!plugin) return defaultWebConfig()
+
+  if (plugin.type === 'npm' || plugin.type === 'git') {
+    const filepath = getWebConfigPath(plugin)
+    if (!filepath) return defaultWebConfig()
+    return getWebConfigMore(filepath)
+  }
+
+  return defaultWebConfig()
+}
+
+/**
+ * 默认web.config参数
+ */
+export const defaultWebConfig = (
+  exists?: boolean,
+  path?: string,
+  customComponent?: boolean,
+  defaultComponent?: boolean
+): PluginAdminListResponse['webConfig'] => {
+  return {
+    exists: exists ?? false,
+    path: path || '',
+    customComponent: customComponent ?? false,
+    defaultComponent: defaultComponent ?? false,
+  }
+}
+
+/**
+ * 获取web.config文件绝对路径
+ */
+const getWebConfigPath = (plugin: PkgInfo) => {
+  const dev = isDev()
+  const pkg = plugin.pkgData
+
+  if (!pkg.karin?.web) return null
+
+  if (dev) {
+    if (!pkg.karin['ts-web']) return null
+    const filepath = path.join(plugin.dir, pkg.karin['ts-web'])
+    if (!fs.existsSync(filepath)) return null
+    return filepath
+  }
+
+  const filepath = path.join(plugin.dir, pkg.karin.web)
+  if (!fs.existsSync(filepath)) return null
+  return filepath
+}
+
+/**
+ * 存在web.config文件 获取更多信息
+ * @param filepath web.config文件绝对路径
+ */
+const getWebConfigMore = async (filepath: string) => {
+  try {
+    const web = await imports(`file://${filepath}`, { isImportDefault: true, isRefresh: isDev() })
+    return defaultWebConfig(
+      true,
+      filepath,
+      typeof web?.customComponent === 'function',
+      typeof web?.defaultComponent === 'function'
+    )
+  } catch (error) {
+    logger.error(new Error('获取插件web.config文件失败', { cause: error }))
+    return defaultWebConfig()
+  }
+}

--- a/packages/core/src/server/plugins/detail/list.ts
+++ b/packages/core/src/server/plugins/detail/list.ts
@@ -217,7 +217,10 @@ export const getFrontendInstalledPluginList: RequestHandler = async (req, res) =
             author: {
               name: market?.author[0].name || '',
               home: market?.author[0].home || '',
-              avatar: market?.author[0].avatar || '',
+              avatar: market?.author[0].avatar ||
+                market?.author[0].home
+                ? `${market?.author[0].home}.png`
+                : '',
             },
             repoUrl: market?.repo[0].url || '',
             hasConfig: webConfig.defaultComponent,

--- a/packages/core/src/server/plugins/detail/list.ts
+++ b/packages/core/src/server/plugins/detail/list.ts
@@ -1,60 +1,118 @@
 import path from 'node:path'
+import { cache, getPluginMarket } from '@/plugin/system'
 import { getPlugins } from '@/plugin/system/list'
-import { cache } from '@/plugin/system'
+import { redis } from '@/core/db'
+import { getNpmLatestVersion } from '@/utils/npm'
+import { KarinPluginType } from '@/types/plugin/market'
+import { getWebConfig, defaultWebConfig } from '../config/webConfig'
 import { getLocalCommitHash, getRemoteCommitHash } from '@/utils/git'
 import { createSuccessResponse, createServerErrorResponse } from '@/server/utils/response'
+import {
+  REDIS_LOCAL_PLUGIN_LIST_CACHE_EXPIRE_FRONTEND,
+  REDIS_LOCAL_PLUGIN_LIST_CACHE_KEY,
+  REDIS_LOCAL_PLUGIN_LIST_CACHE_KEY_FRONTEND,
+  REDIS_PLUGIN_LIST_CACHE_EXPIRE,
+} from '@/env'
 
 import type { RequestHandler } from 'express'
-import type { LoadedPluginCacheList } from '@/types/plugin/cache'
-import type { PluginAdminListResponse } from '@/types/server/plugins'
+import type { LoadedPluginCacheList, PluginAdminListResponse, PkgInfo, FrontendInstalledPluginListResponse } from '@/types'
+
+const git = async (plugin: PkgInfo): Promise<PluginAdminListResponse> => {
+  try {
+    /** 本地最新提交哈希 */
+    const version = await getLocalCommitHash(plugin.dir, { short: true })
+    /** 远程最新提交哈希 */
+    const latestHash = await getRemoteCommitHash(plugin.dir, { short: true })
+    return {
+      type: 'git',
+      id: plugin.pkgData.name,
+      name: plugin.name,
+      version,
+      latestVersion: latestHash,
+      webConfig: await getWebConfig(plugin.name),
+    }
+  } catch (error) {
+    logger.debug(`获取插件${plugin.name}提交哈希失败`, { cache: error })
+    return {
+      type: 'git',
+      id: plugin.pkgData.name,
+      name: plugin.name,
+      version: '0.0.0',
+      latestVersion: '0.0.0',
+      webConfig: await getWebConfig(plugin.name),
+    }
+  }
+}
+
+const npm = async (plugin: PkgInfo): Promise<PluginAdminListResponse> => {
+  return {
+    type: 'npm',
+    id: plugin.pkgData.name,
+    name: plugin.name,
+    version: plugin.pkgData.version,
+    latestVersion: await getNpmLatestVersion(plugin.pkgData.name) || '0.0.0',
+    webConfig: defaultWebConfig(),
+  }
+}
+
+const app = async (plugin: PkgInfo): Promise<PluginAdminListResponse[]> => {
+  return plugin.apps.map(v => {
+    return {
+      type: 'app',
+      id: plugin.name,
+      name: `${plugin.name}/${path.basename(v)}`,
+      version: '',
+      latestVersion: '',
+      webConfig: defaultWebConfig(),
+    }
+  })
+}
+
+/**
+ * 获取插件本地列表`(包含web.config相关配置)`
+ * @param isRefresh 是否强制刷新
+ * @returns 插件列表
+ */
+const getPluginLocalList = async (isRefresh = false): Promise<PluginAdminListResponse[]> => {
+  if (!isRefresh) {
+    const cachedData = await redis.get(REDIS_LOCAL_PLUGIN_LIST_CACHE_KEY)
+    if (cachedData) {
+      return JSON.parse(cachedData)
+    }
+  }
+
+  const list: PluginAdminListResponse[] = []
+  const plugin = await getPlugins('all', true)
+
+  await Promise.all(plugin.map(async plugin => {
+    if (plugin.type === 'git') {
+      return list.push(await git(plugin))
+    }
+    if (plugin.type === 'npm') {
+      return list.push(await npm(plugin))
+    }
+    if (plugin.type === 'app') {
+      const result = await app(plugin)
+      return list.push(...result)
+    }
+  }))
+
+  /** 更新Redis缓存，设置过期时间 */
+  await redis.set(REDIS_LOCAL_PLUGIN_LIST_CACHE_KEY, JSON.stringify(list), {
+    EX: REDIS_PLUGIN_LIST_CACHE_EXPIRE,
+  })
+
+  return list
+}
 
 /**
  * @webui 插件管理 获取插件列表Api
  */
-export const getPluginListPluginAdmin: RequestHandler = async (_, res) => {
+export const getPluginListPluginAdmin: RequestHandler = async (req, res) => {
   try {
-    const list: PluginAdminListResponse[] = []
-    const git = await getPlugins('git', true)
-    const app = await getPlugins('app', true)
-
-    await Promise.all(git.map(async plugin => {
-      try {
-        /** 本地最新提交哈希 */
-        const version = await getLocalCommitHash(plugin.dir, { short: true })
-        /** 远程最新提交哈希 */
-        const latestHash = await getRemoteCommitHash(plugin.dir, { short: true })
-        list.push({
-          type: 'git',
-          id: plugin.pkgData.name,
-          name: plugin.name,
-          version,
-          latestHash,
-        })
-      } catch (error) {
-        logger.debug(`获取插件${plugin.name}提交哈希失败: ${error}`)
-        list.push({
-          type: 'git',
-          id: plugin.pkgData.name,
-          name: plugin.name,
-          version: '0.0.0',
-          latestHash: '0.0.0',
-        })
-      }
-    }))
-
-    app.forEach(plugin => {
-      plugin.apps.forEach(v => {
-        list.push({
-          type: 'app',
-          id: plugin.name,
-          name: `${plugin.name}/${path.basename(v)}`,
-          version: '',
-          latestHash: '',
-        })
-      })
-    })
-
-    createSuccessResponse(res, list)
+    const { isRefresh = false } = req.body
+    const result = await getPluginLocalList(isRefresh)
+    createSuccessResponse(res, result)
   } catch (error) {
     createServerErrorResponse(res, (error as Error).message)
     logger.error(error)
@@ -110,6 +168,68 @@ export const getLoadedCommandPluginCacheList: RequestHandler = async (_, res) =>
     })
 
     createSuccessResponse(res, list)
+  } catch (error) {
+    createServerErrorResponse(res, (error as Error).message)
+    logger.error(error)
+  }
+}
+
+/**
+ * @webui
+ * 获取前端已安装插件简约列表
+ */
+export const getFrontendInstalledPluginList: RequestHandler = async (req, res) => {
+  const isRefresh: boolean = req.body.isRefresh || false
+
+  try {
+    if (!isRefresh) {
+      const cachedData = await redis.get(REDIS_LOCAL_PLUGIN_LIST_CACHE_KEY_FRONTEND)
+      if (cachedData) {
+        return createSuccessResponse(res, JSON.parse(cachedData))
+      }
+    }
+
+    /** 复用同一个获取逻辑 */
+    const [list, marketResult] = await Promise.all([
+      getPlugins('all', false, isRefresh),
+      getPluginMarket(isRefresh),
+    ])
+
+    const marketMap: Record<string, KarinPluginType> = {}
+    marketResult.plugins.forEach(item => {
+      marketMap[item.name] = item
+    })
+
+    const result: FrontendInstalledPluginListResponse[] = await Promise.all(
+      list.map(
+        async item => {
+          const [type, name] = item.split(':') as [FrontendInstalledPluginListResponse['type'], string]
+          /** 是否在插件市场 */
+          const market = marketMap[name]
+          const webConfig = await getWebConfig(name)
+
+          return {
+            id: name,
+            name,
+            type,
+            isMarketPlugin: !!market,
+            description: market?.description || '',
+            author: {
+              name: market?.author[0].name || '',
+              home: market?.author[0].home || '',
+              avatar: market?.author[0].avatar || '',
+            },
+            repoUrl: market?.repo[0].url || '',
+            hasConfig: webConfig.defaultComponent,
+            hasCustomComponent: false,
+          }
+        }))
+
+    createSuccessResponse(res, result)
+    /** 更新Redis缓存，设置过期时间 */
+    await redis.set(REDIS_LOCAL_PLUGIN_LIST_CACHE_KEY_FRONTEND, JSON.stringify(result), {
+      EX: REDIS_LOCAL_PLUGIN_LIST_CACHE_EXPIRE_FRONTEND,
+    })
   } catch (error) {
     createServerErrorResponse(res, (error as Error).message)
     logger.error(error)

--- a/packages/core/src/server/router/index.ts
+++ b/packages/core/src/server/router/index.ts
@@ -50,6 +50,7 @@ import {
   GET_PLUGIN_LIST_PLUGIN_ADMIN_ROUTER,
   GET_LOADED_COMMAND_PLUGIN_CACHE_LIST_ROUTER,
   GET_PLUGIN_MARKET_LIST_ROUTER,
+  GET_LOCAL_PLUGIN_FRONTEND_LIST_ROUTER,
 } from './router'
 import { logMiddleware } from '../log'
 import { authMiddleware } from '../auth/middleware'
@@ -103,7 +104,7 @@ import { getDependenciesListRouter } from '../dependencies/list'
 import { manageDependenciesRouter } from '../dependencies/manage'
 import { taskListRouter, taskRunRouter, taskLogsRouter, taskDeleteRouter } from '../task/list'
 import { getNpmBaseConfigRouter, getNpmrcContentRouter, getNpmrcListRouter, saveNpmrcRouter } from '../dependencies/config'
-import { getLoadedCommandPluginCacheList, getPluginListPluginAdmin } from '../plugins/detail'
+import { getFrontendInstalledPluginList, getLoadedCommandPluginCacheList, getPluginListPluginAdmin } from '../plugins/detail'
 import { getPluginMarketList } from '../plugins/market'
 
 /**
@@ -230,3 +231,5 @@ router.post(TASK_DELETE_ROUTER, taskDeleteRouter)
 router.post(GET_LOADED_COMMAND_PLUGIN_CACHE_LIST_ROUTER, getLoadedCommandPluginCacheList)
 /** @version 1.8.0 获取插件市场列表 */
 router.post(GET_PLUGIN_MARKET_LIST_ROUTER, getPluginMarketList)
+/** @version 1.8.0 获取本地插件列表 用于插件索引页面渲染简约列表 */
+router.post(GET_LOCAL_PLUGIN_FRONTEND_LIST_ROUTER, getFrontendInstalledPluginList)

--- a/packages/core/src/server/router/router.ts
+++ b/packages/core/src/server/router/router.ts
@@ -121,3 +121,6 @@ export const SAVE_NPMRC_ROUTER = '/dependencies/npmrc/save'
 export const GET_LOADED_COMMAND_PLUGIN_CACHE_LIST_ROUTER = '/plugin/loaded/command'
 /** @version 1.8.0 获取插件市场列表 */
 export const GET_PLUGIN_MARKET_LIST_ROUTER = '/plugin/market'
+
+/** @version 1.8.0 获取本地插件列表 用于插件索引页面渲染简约列表 */
+export const GET_LOCAL_PLUGIN_FRONTEND_LIST_ROUTER = '/plugin/local/frontend'

--- a/packages/core/src/types/server/local.ts
+++ b/packages/core/src/types/server/local.ts
@@ -80,7 +80,7 @@ export interface SaveConfigResponse {
 export interface DefineConfig<T = any> {
   /** 插件信息 */
   info: {
-    /** 插件id */
+    /** 插件id 也就是插件的包名 */
     id: string
     /** 插件名称 前端优先展示 */
     name?: string
@@ -93,12 +93,17 @@ export interface DefineConfig<T = any> {
     /** 插件描述 可不填 会自动读取package.json中的version */
     description?: string
   },
-  /** 组件配置参数 */
-  components: () => ComponentConfig[] | Promise<ComponentConfig[]>
+  /** 默认组件配置参数 */
+  components?: () => ComponentConfig[] | Promise<ComponentConfig[]>
   /**
    * 保存配置
    * @param config 配置
    * @returns 保存结果
    */
-  save: (config: T) => SaveConfigResponse | Promise<SaveConfigResponse>
+  save?: (config: T) => SaveConfigResponse | Promise<SaveConfigResponse>
+  /**
+   * 自定义组件配置
+   * @description 未完成
+   */
+  customComponent?: () => unknown
 }

--- a/packages/core/src/types/server/plugins.ts
+++ b/packages/core/src/types/server/plugins.ts
@@ -91,8 +91,54 @@ export interface PluginAdminListResponse {
   type: KarinPluginAppsType
   /** 插件版本 App类型为空 */
   version: string
-  /** 插件最新版本短哈希 App类型为空 */
-  latestHash: string
+  /**
+   * 插件最新版本
+   * - npm: 最新版本号
+   * - git: 最新提交哈希
+   * - app: 最新版本号
+   */
+  latestVersion: string
+  webConfig: {
+    /** 是否存在`web.config`文件 */
+    exists: boolean
+    /** wen.config 文件绝对路径 */
+    path: string
+    /** 是否存在自定义组件配置函数 */
+    customComponent: boolean
+    /** 是否存在默认组件配置函数 一般用于插件的配置文件管理 */
+    defaultComponent: boolean
+  }
+}
+
+/**
+ * 前端已安装插件简约列表 用于在插件管理索引页面显示
+ */
+export interface FrontendInstalledPluginListResponse {
+  /** 插件ID `package.json中的名称` */
+  id: string
+  /** 插件名称 */
+  name: string
+  /** 插件类型 */
+  type: KarinPluginAppsType
+  /** 插件是否存在插件市场中 */
+  isMarketPlugin: boolean
+  /** 插件描述 */
+  description: string
+  /** 插件作者信息 */
+  author: {
+    /** 名字 */
+    name: string
+    /** 主页 */
+    home: string
+    /** 头像 */
+    avatar: string
+  }
+  /** 插件仓库主页 */
+  repoUrl: string
+  /** 插件是否可配置 */
+  hasConfig: boolean
+  /** 插件是否存在自定义组件 */
+  hasCustomComponent: boolean
 }
 
 /**

--- a/packages/core/src/types/utils/npm.ts
+++ b/packages/core/src/types/utils/npm.ts
@@ -1,7 +1,7 @@
 /** .npmrc文件列表接口响应 */
 export interface NpmrcFileResponse {
   path: string
-  type: 'global' | 'project' | 'pnpm'
+  type: string
   description: string
 }
 
@@ -10,4 +10,65 @@ export interface NpmBaseConfigResponse {
   registry: string
   proxy: string
   'https-proxy': string
+}
+
+/** npm registry配置 */
+export interface NpmRegistryResponse {
+  _id: string
+  _rev: string
+  name: string
+  'dist-tags': {
+    latest: string
+    [key: string]: string
+  },
+  versions: Record<string, {
+    name: string
+    version: string
+    license: string,
+    _id: string,
+    maintainers: [
+      {
+        name: string,
+        email: string
+      }
+    ],
+    dist: {
+      shasum: string,
+      tarball: string,
+      fileCount: number,
+      integrity: string,
+      signatures: {
+        sig: string,
+        keyid: string
+      }[],
+      unpackedSize: number
+    },
+    gitHead: string,
+    _npmUser: {
+      name: string,
+      email: string
+    },
+    _npmVersion: string,
+    _nodeVersion: string,
+    _hasShrinkwrap: false,
+    _npmOperationalInternal: {
+      tmp: string,
+      host: string
+    }
+    [key: string]: any
+  }>
+  time: Record<string, string>
+  maintainers: [
+    {
+      name: string,
+      email: string
+    },
+    {
+      name: string,
+      email: string
+    }
+  ],
+  readme: string,
+  readmeFilename: string
+  [key: string]: any
 }

--- a/packages/core/src/utils/npm/index.ts
+++ b/packages/core/src/utils/npm/index.ts
@@ -1,1 +1,2 @@
 export * from './npmrc'
+export * from './registry'

--- a/packages/core/src/utils/npm/registry.ts
+++ b/packages/core/src/utils/npm/registry.ts
@@ -1,0 +1,47 @@
+import axios from 'axios'
+import { exec } from '@/utils/system/exec'
+import type { NpmRegistryResponse } from '@/types'
+
+/**
+ * 获取registry
+ */
+export const getRegistry = async () => {
+  if (process.env.npm_config_registry) {
+    return process.env.npm_config_registry
+  }
+
+  const registry = await exec('npm config get registry')
+  process.env.npm_config_registry = registry.stdout
+  return registry.stdout
+}
+
+/**
+ * 获取一个npm包registry配置
+ * @param name - 包名
+ * @returns registry
+ */
+export const getNpmRegistry = async (name: string): Promise<NpmRegistryResponse> => {
+  /** 获取npm源 */
+  const registry = await getRegistry()
+  /** 请求npm源 */
+  const response = await axios.get(`${registry}/${name}`)
+  return response.data
+}
+
+/**
+ * 获取一个npm包的最新版本
+ * @param name - 包名
+ * @returns 最新版本
+ */
+export const getNpmLatestVersion = async (name: string) => {
+  try {
+    const result = await getNpmRegistry(name)
+    return result['dist-tags'].latest
+  } catch (error) {
+    logger.debug(new Error(`获取${name}最新版本失败`, { cause: error }))
+    return null
+  }
+}
+
+/** 初始化一下 防止并发 */
+getRegistry()

--- a/packages/core/src/utils/request/race.ts
+++ b/packages/core/src/utils/request/race.ts
@@ -218,8 +218,13 @@ export const getFastRegistry = async (): Promise<string> => {
     'https://mirrors.cloud.tencent.com/npm',
   ]
 
-  const result = await raceRequest(urls)
-  return result?.config.url || urls[0]
+  try {
+    const result = await raceRequest(urls)
+    return result?.config.url || urls[0]
+  } catch (error) {
+    console.error('获取最快的npm registry失败:', error)
+    return urls[0]
+  }
 }
 
 /**

--- a/packages/core/src/utils/system/import.ts
+++ b/packages/core/src/utils/system/import.ts
@@ -16,3 +16,22 @@ export const importModule = async <T = any> (
     return { status: false, data: error }
   }
 }
+
+/**
+ * 动态导入模块
+ * @param url 模块地址 仅支持绝对路径 无需传递 `file://` 前缀
+ * @param options 选项
+ * @param options.isRefresh 是否重新加载 不使用缓存
+ * @param options.isImportDefault 是否返回默认导出
+ */
+export const imports = async <T = any> (url: string, options: {
+  isRefresh?: boolean
+  isImportDefault?: boolean
+} = {}): Promise<T> => {
+  const { isRefresh = false, isImportDefault = true } = options
+  const module = await import(`file://${url}${isRefresh ? `?t=${Date.now()}` : ''}`)
+  if (isImportDefault) {
+    return module.default
+  }
+  return module
+}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -8,6 +8,7 @@ const LoadingPage = lazy(() => import('@/pages/loading'))
 const DashboardLayout = lazy(() => import('@/pages/dashboard/layout'))
 const IndexPage = lazy(() => import('@/pages/dashboard'))
 const ConfigPage = lazy(() => import('@/pages/dashboard/config/index'))
+const PluginsDashboardPage = lazy(() => import('@/pages/dashboard/plugins-dashboard'))
 const PluginMarketPage = lazy(() => import('@/pages/dashboard/plugins'))
 const PluginConfigPage = lazy(() => import('@/pages/dashboard/plugins/config'))
 const PluginManagePage = lazy(() => import('@/pages/dashboard/plugins/manage'))
@@ -41,6 +42,7 @@ function App () {
         >
           <Route element={<IndexPage />} path='' />
           <Route element={<TerminalPage />} path='/terminal' />
+          <Route element={<PluginsDashboardPage />} path='/plugins-dashboard' />
           <Route element={<WebUIPluginPage />} path='/plugins/webui' />
           <Route element={<DependenciesPage />} path='/dependencies' />
           <Route element={<ConfigPage />} path='/config/*'>

--- a/packages/web/src/components/card/BasicCard.tsx
+++ b/packages/web/src/components/card/BasicCard.tsx
@@ -1,19 +1,20 @@
 import type { BaseCardProps } from './types'
+import { Tooltip } from '@heroui/tooltip'
 
 /**
- * 统计卡片组件属性接口
+ * 基础卡片组件属性接口
  */
-export interface StatCardProps extends BaseCardProps {
-  /** 显示的数字 */
-  count: number
+export interface BasicCardProps extends BaseCardProps {
+  /** 卡片标题 */
+  title: string
 }
 
 /**
- * 通用统计卡片组件
- * 用于显示带有图标和数字的统计信息
+ * 通用基础卡片组件
+ * 用于显示带有图标和标题的信息
  */
-const StatCard = ({
-  count,
+const BasicCard = ({
+  title,
   description,
   icon,
   iconDot,
@@ -24,8 +25,9 @@ const StatCard = ({
   ringColor,
   isActive,
   onClick,
-}: StatCardProps) => {
-  return (
+  tooltip,
+}: BasicCardProps) => {
+  const cardContent = (
     <div
       onClick={onClick}
       className={`
@@ -44,12 +46,22 @@ const StatCard = ({
           </div>
         </div>
         <div>
-          <div className='text-xl md:text-2xl font-light'>{count}</div>
+          <div className='text-lg md:text-x2 font-medium'>{title}</div>
           <div className='text-xs md:text-sm text-default-500'>{description}</div>
         </div>
       </div>
     </div>
   )
+
+  if (tooltip) {
+    return (
+      <Tooltip content={tooltip} placement='top' showArrow>
+        {cardContent}
+      </Tooltip>
+    )
+  }
+
+  return cardContent
 }
 
-export default StatCard
+export default BasicCard

--- a/packages/web/src/components/card/index.ts
+++ b/packages/web/src/components/card/index.ts
@@ -1,1 +1,5 @@
 export { default as StatCard } from './StatCard'
+export { default as BasicCard } from './BasicCard'
+export * from './types'
+export type { StatCardProps } from './StatCard'
+export type { BasicCardProps } from './BasicCard'

--- a/packages/web/src/components/card/types.ts
+++ b/packages/web/src/components/card/types.ts
@@ -1,0 +1,29 @@
+import { ReactNode } from 'react'
+
+/**
+ * 基础卡片属性接口
+ */
+export interface BaseCardProps {
+  /** 图标 */
+  icon: ReactNode
+  /** 图标右上角小点 */
+  iconDot?: ReactNode
+  /** 卡片描述文本 */
+  description: string
+  /** 背景渐变样式 */
+  gradient: string
+  /** 边框样式 */
+  border: string
+  /** 图标背景样式 */
+  iconBg: string
+  /** 文字颜色样式 */
+  textColor: string
+  /** 选中时的环形颜色 */
+  ringColor: string
+  /** 是否处于激活状态 */
+  isActive: boolean
+  /** 点击事件处理函数 */
+  onClick: () => void
+  /** 悬浮提示内容，如果提供则显示tooltip */
+  tooltip?: string
+}

--- a/packages/web/src/components/plugin/admin/FilterCards.tsx
+++ b/packages/web/src/components/plugin/admin/FilterCards.tsx
@@ -35,7 +35,6 @@ const FilterCards: FC<FilterCardsProps> = ({ counts, selectedType, onTypeChange 
   return (
     <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8'>
       <StatCard
-        title='全部'
         count={counts.all}
         description='全部插件'
         icon={renderIcon(24, IoSettingsOutline)}
@@ -49,7 +48,6 @@ const FilterCards: FC<FilterCardsProps> = ({ counts, selectedType, onTypeChange 
       />
 
       <StatCard
-        title='NPM插件'
         count={counts.npm}
         description='Npm包插件'
         icon={renderIcon(24, FaNpm)}
@@ -63,7 +61,6 @@ const FilterCards: FC<FilterCardsProps> = ({ counts, selectedType, onTypeChange 
       />
 
       <StatCard
-        title='Git插件'
         count={counts.git}
         description='Git 插件'
         icon={renderIcon(24, TbBrandGit)}
@@ -77,7 +74,6 @@ const FilterCards: FC<FilterCardsProps> = ({ counts, selectedType, onTypeChange 
       />
 
       <StatCard
-        title='App插件'
         count={counts.app}
         description={window.innerWidth <= 640 ? 'App插件 (插件名称省略了前缀)' : 'App插件'}
         icon={renderIcon(24, TbApps)}

--- a/packages/web/src/components/plugin/admin/PluginRow.tsx
+++ b/packages/web/src/components/plugin/admin/PluginRow.tsx
@@ -41,7 +41,7 @@ const PluginRow = memo(({
   onUninstall,
 }: PluginRowProps) => {
   /** 插件更新状态 */
-  const statusConfig = getUpdateStatusConfig(plugin.type, plugin.version, plugin.latestHash)
+  const statusConfig = getUpdateStatusConfig(plugin.type, plugin.version, plugin.latestVersion)
   /** 插件类型配置 */
   const typeConfig = getTypeConfig(plugin.type)
 
@@ -149,10 +149,10 @@ const PluginRow = memo(({
             <span className='text-xs text-default-500'>-</span>
           )
           : (
-            plugin.latestHash !== plugin.version
+            plugin.latestVersion !== plugin.version && plugin.latestVersion !== '0.0.0'
               ? (
                 <Chip size='sm' variant='flat' color='warning' className='bg-warning-100/50'>
-                  {plugin.latestHash}
+                  {plugin.latestVersion}
                 </Chip>
               )
               : (
@@ -254,21 +254,27 @@ const PluginRow = memo(({
                 <IoSettingsOutline className='text-lg' />
               </Button>
             </DropdownTrigger>
-            <DropdownMenu aria-label='插件操作' onAction={handleDropdownAction}>
+            <DropdownMenu
+              aria-label='插件操作'
+              onAction={handleDropdownAction}
+              classNames={{
+                base: 'text-default-600',
+              }}
+            >
               {/* 配置选项 - 只有git类型才显示 */}
-              {/* {plugin.type === 'git'
+              {plugin.webConfig.defaultComponent
                 ? (
-                  <DropdownItem key='settings' description='调整插件配置'>
+                  <DropdownItem key='settings' description='调整插件配置' className='text-default-600'>
                     <div className='flex items-center gap-2'>
                       <IoSettingsOutline />
                       <span>插件配置</span>
                     </div>
                   </DropdownItem>
                 )
-                : null} */}
+                : null}
 
               {/* 更新按钮 - 对app类型不显示且必须是可更新状态 */}
-              {plugin.type !== 'app' && plugin.version !== plugin.latestHash
+              {plugin.type !== 'app' && plugin.version !== plugin.latestVersion && plugin.latestVersion !== '0.0.0'
                 ? (
                   <DropdownItem key='update' description='更新到最新版本' className='text-success'>
                     <div className='flex items-center gap-2'>
@@ -282,7 +288,7 @@ const PluginRow = memo(({
               {/* Git类型特有的强制更新按钮 */}
               {plugin.type === 'git'
                 ? (
-                  <DropdownItem key='forceUpdate' description='强制拉取最新代码' className='text-warning'>
+                  <DropdownItem key='forceUpdate' description='强制拉取最新代码' className='text-primary'>
                     <div className='flex items-center gap-2'>
                       <TbArrowsUp />
                       <span>强制更新</span>
@@ -292,8 +298,8 @@ const PluginRow = memo(({
                 : null}
 
               {/* 卸载按钮 - 所有类型都显示 */}
-              <DropdownItem key='uninstall' description='从系统移除此插件' className='text-danger'>
-                <div className='flex items-center gap-2'>
+              <DropdownItem key='uninstall' description='从系统移除此插件' className='text-default-600'>
+                <div className='flex items-center gap-2 text-danger-400'>
                   <TbTrash />
                   <span>卸载插件</span>
                 </div>

--- a/packages/web/src/components/plugin/index/LoadingState.tsx
+++ b/packages/web/src/components/plugin/index/LoadingState.tsx
@@ -1,0 +1,25 @@
+import { Card, CardBody } from '@heroui/card'
+import { Skeleton } from '@heroui/skeleton'
+
+/**
+ * 加载状态组件
+ */
+const LoadingState = () => {
+  return (
+    <Card className='border border-default-200/50 dark:border-default-800/30' shadow='none'>
+      <CardBody className='py-6 flex flex-col gap-6'>
+        {[1, 2, 3].map((i) => (
+          <div key={i} className='flex items-center gap-4'>
+            <Skeleton className='w-12 h-12 rounded-full' />
+            <div className='flex-1'>
+              <Skeleton className='h-5 w-1/3 mb-2 rounded-full' />
+              <Skeleton className='h-4 w-2/3 rounded-full' />
+            </div>
+          </div>
+        ))}
+      </CardBody>
+    </Card>
+  )
+}
+
+export default LoadingState

--- a/packages/web/src/components/plugin/index/Local.tsx
+++ b/packages/web/src/components/plugin/index/Local.tsx
@@ -53,7 +53,6 @@ const LocalPluginList = () => {
     }
   )
 
-  console.log('接口返回:', plugins)
   const pageSize = 16
 
   /** 计算总页数 */
@@ -81,7 +80,15 @@ const LocalPluginList = () => {
   const currentPagePlugins = useMemo(
     () => {
       const startIndex = (page - 1) * pageSize
-      return plugins.slice(startIndex, startIndex + pageSize)
+
+      /** 根据 hasConfig 排序后的插件列表 */
+      const sortedPlugins = plugins.sort((a, b) => {
+        if (a.hasConfig && !b.hasConfig) return -1
+        if (!a.hasConfig && b.hasConfig) return 1
+        return 0
+      })
+
+      return sortedPlugins.slice(startIndex, startIndex + pageSize)
     },
     [plugins, page, pageSize]
   )

--- a/packages/web/src/components/plugin/index/Local.tsx
+++ b/packages/web/src/components/plugin/index/Local.tsx
@@ -42,9 +42,9 @@ const LocalPluginList = () => {
         if (isManualRefresh) {
           const duration = ((Date.now() - refreshStartTimeRef.current) / 1000).toFixed(1)
           if (!onlineError) {
-            toast.success(`刷新成功，耗时 ${duration} 秒`)
+            toast.success(`刷新成功，耗时 ${duration} 秒`, { id: 'refresh-plugins' })
           } else {
-            toast.error(`刷新失败，耗时 ${duration} 秒`)
+            toast.error(`刷新失败: ${onlineError.message}`, { id: 'refresh-plugins' })
           }
         }
         setIsRefreshing(false)
@@ -120,7 +120,6 @@ const LocalPluginList = () => {
 
     refreshTimeoutRef.current = setTimeout(() => {
       refreshPlugins()
-      toast.dismiss('refresh-plugins')
     }, 100)
   }, [onlineLoading, isRefreshing, refreshPlugins])
 
@@ -137,8 +136,9 @@ const LocalPluginList = () => {
               onPress={handleRefresh}
               startContent={<IoRefreshOutline />}
               disabled={isRefreshing}
+              isLoading={isRefreshing}
             >
-              重试
+              {isRefreshing ? '刷新中...' : '重试'}
             </Button>
           </CardBody>
         </Card>

--- a/packages/web/src/components/plugin/index/Local.tsx
+++ b/packages/web/src/components/plugin/index/Local.tsx
@@ -1,0 +1,168 @@
+import { useMemo, useState, useEffect, useRef, useCallback } from 'react'
+import { useRequest } from 'ahooks'
+import { getFrontendInstalledPluginListRequest } from '@/request/plugins'
+import { Pagination } from '@heroui/pagination'
+import { Button } from '@heroui/button'
+import { Spinner } from '@heroui/spinner'
+import { Card, CardBody } from '@heroui/card'
+import { ScrollShadow } from '@heroui/scroll-shadow'
+import PluginCard from './card'
+import {
+  IoRefreshOutline,
+} from 'react-icons/io5'
+import type { FrontendInstalledPluginListResponse } from 'node-karin'
+
+/**
+ * 插件市场页面：顶部大Banner+内容区风格
+ * @returns 插件市场主页面组件
+ */
+const LocalPluginList = () => {
+  // 从URL获取初始页码
+  const getInitialPage = (): number => {
+    const searchParams = new URLSearchParams(location.search)
+    const pageParam = searchParams.get('page')
+    return pageParam && !isNaN(Number(pageParam)) ? Number(pageParam) : 1
+  }
+
+  const [page, setPage] = useState(getInitialPage())
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const refreshTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  const {
+    data: plugins = [],
+    error: onlineError,
+    loading: onlineLoading,
+    refresh: refreshPlugins,
+  } = useRequest<FrontendInstalledPluginListResponse[], [boolean]>(
+    () => getFrontendInstalledPluginListRequest(isRefreshing),
+    {
+      refreshDeps: [isRefreshing],
+      onFinally: () => setIsRefreshing(false),
+    }
+  )
+
+  console.log('接口返回:', plugins)
+  const pageSize = 16
+
+  // 计算总页数
+  const totalPages = useMemo(() => Math.ceil(plugins.length / pageSize), [plugins.length, pageSize])
+
+  // 确保页码不超出范围
+  useEffect(() => {
+    if (totalPages > 0 && page > totalPages) {
+      setPage(totalPages)
+    }
+  }, [totalPages, page])
+
+  // 当前页插件数据
+  const currentPagePlugins = useMemo(
+    () => {
+      const startIndex = (page - 1) * pageSize
+      return plugins.slice(startIndex, startIndex + pageSize)
+    },
+    [plugins, page, pageSize]
+  )
+
+  // 监听外部事件更新列表
+  useEffect(() => {
+    const handlePluginUpdate = () => {
+      refreshPlugins()
+    }
+
+    window.addEventListener('plugin-list-update', handlePluginUpdate)
+    return () => {
+      window.removeEventListener('plugin-list-update', handlePluginUpdate)
+    }
+  }, [refreshPlugins])
+
+  // 刷新函数
+  const handleRefresh = useCallback(() => {
+    if (onlineLoading || isRefreshing) return
+
+    if (refreshTimeoutRef.current) {
+      clearTimeout(refreshTimeoutRef.current)
+    }
+    setIsRefreshing(true)
+    refreshTimeoutRef.current = setTimeout(() => {
+      refreshPlugins()
+    }, 100)
+  }, [onlineLoading, isRefreshing, refreshPlugins])
+
+  if (onlineError) {
+    return (
+      <div className='h-full flex items-center justify-center'>
+        <Card className='max-w-md mx-auto'>
+          <CardBody className='flex flex-col items-center gap-4 py-8'>
+            <div className='text-xl font-medium text-danger'>加载失败</div>
+            <p className='text-center text-default-600'>{onlineError.message}</p>
+            <Button
+              color='primary'
+              variant='flat'
+              onPress={handleRefresh}
+              startContent={<IoRefreshOutline />}
+              disabled={isRefreshing}
+            >
+              重试
+            </Button>
+          </CardBody>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div className='flex-1 flex flex-col items-center justify-start w-full relative z-10'>
+        <div className='w-full max-w-[1600px] mx-auto flex-1 flex flex-col py-4 px-4'>
+          <ScrollShadow className='w-full h-full flex-1' hideScrollBar>
+            {onlineLoading && plugins.length === 0 && (
+              <div className='h-full flex items-center justify-center'>
+                <Spinner size='lg' color='primary' />
+              </div>
+            )}
+            {currentPagePlugins.length > 0
+              ? (
+                <div className='grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-5 p-2'>
+                  {currentPagePlugins.map(plugin => (
+                    <PluginCard
+                      key={plugin.id}
+                      plugin={plugin}
+                      cardClassName='shadow-md border border-default-200 dark:border-default-200 hover:border-primary-400 dark:hover:border-primary-500 transition-colors'
+                    />
+                  ))}
+                </div>
+              )
+              : !onlineLoading && (
+                <div className='h-full flex items-center justify-center'>
+                  <div className='text-center'>
+                    <p className='text-lg font-medium text-default-900 mb-1'>暂无插件</p>
+                    <p className='text-xs text-default-600'>
+                      当前没有任何插件
+                    </p>
+                  </div>
+                </div>
+              )}
+          </ScrollShadow>
+        </div>
+      </div>
+
+      {
+        plugins.length > 0 && (
+          <div className='w-full flex justify-center py-6'>
+            <Pagination
+              showControls
+              showShadow
+              color='primary'
+              size='sm'
+              page={page}
+              total={totalPages}
+              onChange={page => setPage(page)}
+            />
+          </div>
+        )
+      }
+    </>
+  )
+}
+
+export default LocalPluginList

--- a/packages/web/src/components/plugin/index/Local.tsx
+++ b/packages/web/src/components/plugin/index/Local.tsx
@@ -8,9 +8,7 @@ import { Spinner } from '@heroui/spinner'
 import { Card, CardBody } from '@heroui/card'
 import { ScrollShadow } from '@heroui/scroll-shadow'
 import PluginCard from './card'
-import {
-  IoRefreshOutline,
-} from 'react-icons/io5'
+import { IoRefreshOutline } from 'react-icons/io5'
 import type { FrontendInstalledPluginListResponse } from 'node-karin'
 
 /**

--- a/packages/web/src/components/plugin/index/LocalPlugin.tsx
+++ b/packages/web/src/components/plugin/index/LocalPlugin.tsx
@@ -1,34 +1,22 @@
 import { useRequest } from 'ahooks'
-import { Button } from '@heroui/button'
 import { Spinner } from '@heroui/spinner'
-import { useSearchParams, useNavigate } from 'react-router-dom'
-import { MdOutlineExtension } from 'react-icons/md'
-import { createUpdatePlugins } from '@/utils/updatePlugins.utils'
+import { Button } from '@heroui/button'
 import { TbArrowsUp, TbRefresh, TbTrash } from 'react-icons/tb'
 import TaskLogModal from '@/components/dependencies/TaskLogModal'
 import { getLocalPluginNameListRequest } from '@/request/plugins'
-import { hideRocket } from '@/components/common/ScrollToTop.utils'
-import { useState, useCallback, ReactElement, useEffect, useMemo } from 'react'
-import { FilterCards, TableContent, UpdateOptionsModal } from '@/components/plugin/admin'
+import { createUpdatePlugins } from '@/utils/updatePlugins.utils'
+import { useState, useCallback, ReactElement, useMemo, useRef } from 'react'
+import { TableContent, UpdateOptionsModal } from '@/components/plugin/admin'
 
-import type { PluginType } from '@/components/plugin/admin'
 import type { PluginAdminListResponse, PluginAdminParams } from 'node-karin'
 
 /**
- * 插件管理页面组件
- * @returns 返回插件管理页面
+ * 本地插件列表组件
+ * @returns 返回插件列表虚拟滚动组件
  */
-export const PluginManagePage = (): ReactElement => {
-  /** 是否为首次挂载组件 */
-  const [isFirstLoad, setIsFirstLoad] = useState(true)
-
-  /** 使用 URL 搜索参数管理筛选状态 */
-  const [searchParams, setSearchParams] = useSearchParams()
-
-  /** 选中的插件类型 - 从 URL 参数中获取，默认为 'all' */
-  const [selectedType, setSelectedType] = useState<PluginType>(
-    (searchParams.get('type') as PluginType) || 'all'
-  )
+export const LocalPlugin = (): ReactElement => {
+  /** 标记是否为首次加载 */
+  const isFirstLoad = useRef(true)
 
   /** 选中的插件ID列表（使用Set保证唯一性和便于操作） */
   const [selectedKeys, setSelectedKeys] = useState(new Set<string>())
@@ -48,16 +36,14 @@ export const PluginManagePage = (): ReactElement => {
   /** 任务名称 */
   const [taskName, setTaskName] = useState<string>('更新全部插件')
 
-  /** 存储所有插件数据，用于前端筛选 */
+  /** 存储所有插件数据 */
   const [allPlugins, setAllPlugins] = useState<PluginAdminListResponse[]>([])
 
   /** 本地筛选时的加载状态 */
-  const [localFiltering, setLocalFiltering] = useState(false)
+  const [localFiltering] = useState(false)
 
   /** 延迟显示空结果的状态，避免与虚拟列表加载过程冲突 */
-  const [delayEmptyResult, setDelayEmptyResult] = useState(false)
-
-  const navigate = useNavigate()
+  const [delayEmptyResult] = useState(false)
 
   /**
    * 获取插件列表的请求 - 只在组件挂载和手动刷新时触发
@@ -65,16 +51,17 @@ export const PluginManagePage = (): ReactElement => {
   const { loading: remoteLoading, run: fetchPlugins } = useRequest(
     async () => {
       try {
-        let isRefresh = false
-        if (isFirstLoad) {
-          setIsFirstLoad(false)
-        } else {
-          isRefresh = true
+        // 如果是首次加载，传false；如果是手动刷新，传true
+        const isRefresh = !isFirstLoad.current
+        const pluginsResponse = await getLocalPluginNameListRequest(isRefresh)
+
+        // 更新首次加载标记
+        if (isFirstLoad.current) {
+          isFirstLoad.current = false
         }
 
-        const result = await getLocalPluginNameListRequest(isRefresh)
-        setAllPlugins(result)
-        return result
+        setAllPlugins(pluginsResponse)
+        return pluginsResponse
       } catch (error) {
         console.error('获取插件列表失败:', error)
         return []
@@ -89,16 +76,6 @@ export const PluginManagePage = (): ReactElement => {
     }
   )
 
-  /** 综合加载状态，仅在远程加载时显示为true，本地筛选不显示加载状态 */
-  const loading = remoteLoading && !localFiltering
-
-  /** 根据选择的筛选器类型在前端筛选插件数据 */
-  const plugins = useMemo(() => {
-    return selectedType === 'all'
-      ? allPlugins
-      : allPlugins.filter(plugin => plugin.type === selectedType)
-  }, [allPlugins, selectedType])
-
   /** 行高定义 */
   const rowHeight = useMemo(() => {
     return window.innerWidth < 768 ? 50 : 60
@@ -107,9 +84,9 @@ export const PluginManagePage = (): ReactElement => {
   /** 容器高度 */
   const containerHeight = useMemo(() => {
     const availableHeight = window.innerHeight * 0.6
-    const contentHeight = (plugins?.length || 0) * rowHeight
+    const contentHeight = (allPlugins.length || 0) * rowHeight
     return Math.min(Math.max(contentHeight || 300, 300), availableHeight)
-  }, [plugins, rowHeight])
+  }, [allPlugins, rowHeight])
 
   /** 为选中状态创建映射表以加速查找 */
   const selectedMap = useMemo(() => {
@@ -120,53 +97,22 @@ export const PluginManagePage = (): ReactElement => {
 
   /** 全选状态 */
   const selectionState = useMemo(() => {
-    if (!plugins || plugins.length === 0) return { isSelected: false, isIndeterminate: false }
+    if (!allPlugins || allPlugins.length === 0) return { isSelected: false, isIndeterminate: false }
     const selectedCount = selectedKeys.size
 
     // 完全选中
-    if (selectedCount === plugins.length) {
+    if (selectedCount === allPlugins.length) {
       return { isSelected: true, isIndeterminate: false }
     }
 
     // 部分选中
-    if (selectedCount > 0 && selectedCount < plugins.length) {
+    if (selectedCount > 0 && selectedCount < allPlugins.length) {
       return { isSelected: false, isIndeterminate: true }
     }
 
     // 未选中
     return { isSelected: false, isIndeterminate: false }
-  }, [plugins, selectedKeys])
-
-  /** 当 URL 参数变化时更新选中类型 */
-  useEffect(() => {
-    const typeParam = searchParams.get('type') as PluginType
-    if (typeParam && typeParam !== selectedType) {
-      setSelectedType(typeParam)
-    }
-  }, [searchParams, selectedType])
-
-  /**
-   * 处理类型变更
-   * @param type - 新的筛选类型
-   */
-  const handleTypeChange = useCallback((type: PluginType) => {
-    // 本地筛选开始
-    setLocalFiltering(true)
-    // 启用延迟空结果显示
-    setDelayEmptyResult(true)
-    setSelectedType(type)
-    /** 更新 URL 参数 */
-    setSearchParams({ type })
-    /** 重置选中的插件 */
-    setSelectedKeys(new Set())
-
-    // 筛选完成后重置筛选状态
-    // 延长时间以确保完全覆盖LazyPluginLoader的分片加载过程
-    setTimeout(() => setLocalFiltering(false), 800)
-
-    // 延迟更长时间后才显示"没有找到符合条件的插件"
-    setTimeout(() => setDelayEmptyResult(false), 1000)
-  }, [setSearchParams])
+  }, [allPlugins, selectedKeys])
 
   /**
    * 处理选择插件
@@ -196,27 +142,19 @@ export const PluginManagePage = (): ReactElement => {
 
     // 根据插件类型处理
     if (plugin.type === 'npm') {
-      // NPM插件 - 找到该依赖并导航到依赖管理页面
-      navigate(`/dependencies?search=${encodeURIComponent(pluginId)}`)
+      // NPM插件 - 这里需要外部处理
+      console.log('打开NPM插件设置:', pluginId)
     } else {
       // 其他类型插件的设置逻辑
       console.log('打开插件设置:', pluginId)
-      // 这里可以实现导航到设置页面或者打开设置模态框的逻辑
     }
-  }, [allPlugins, navigate])
-
-  /**
-   * 获取当前选中的插件数量
-   */
-  const getSelectedCount = useCallback(() => {
-    return selectedKeys.size
-  }, [selectedKeys])
+  }, [allPlugins])
 
   /**
    * 处理全选/取消全选
    */
   const handleSelectAll = useCallback(() => {
-    if (plugins && plugins.length > 0) {
+    if (allPlugins && allPlugins.length > 0) {
       if (selectedKeys.size > 0) {
         /** 如果有选中项，则取消全选 */
         console.log('取消全选，清空所有选中项')
@@ -224,11 +162,11 @@ export const PluginManagePage = (): ReactElement => {
       } else {
         /** 否则全选 */
         console.log('全选，选中所有项')
-        const allKeys = new Set(plugins.map(plugin => plugin.name))
+        const allKeys = new Set(allPlugins.map(plugin => plugin.name))
         setSelectedKeys(allKeys as Set<string>)
       }
     }
-  }, [plugins, selectedKeys])
+  }, [allPlugins, selectedKeys])
 
   /**
    * 通用的插件管理操作处理函数
@@ -254,10 +192,16 @@ export const PluginManagePage = (): ReactElement => {
   }, [])
 
   /**
+   * 获取当前选中的插件数量
+   */
+  const getSelectedCount = useCallback(() => {
+    return selectedKeys.size
+  }, [selectedKeys])
+
+  /**
    * 处理更新全部按钮点击
    */
   const handleUpdateAll = useCallback(() => {
-    hideRocket()
     setUpdateModalOpen(true)
   }, [])
 
@@ -268,7 +212,7 @@ export const PluginManagePage = (): ReactElement => {
     if (selectedKeys.size === 0) return
 
     // 查找选中的插件详情
-    const selectedPlugins = plugins.filter(plugin => selectedKeys.has(plugin.name))
+    const selectedPlugins = allPlugins.filter(plugin => selectedKeys.has(plugin.name))
 
     // 准备更新参数
     const params: PluginAdminParams = {
@@ -284,7 +228,7 @@ export const PluginManagePage = (): ReactElement => {
 
     // 使用通用处理函数
     handlePluginOperation(params)
-  }, [plugins, selectedKeys, handlePluginOperation])
+  }, [allPlugins, selectedKeys, handlePluginOperation])
 
   /**
    * 处理卸载选中插件按钮点击
@@ -293,7 +237,7 @@ export const PluginManagePage = (): ReactElement => {
     if (selectedKeys.size === 0) return
 
     // 查找选中的插件详情
-    const selectedPlugins = plugins.filter(plugin => selectedKeys.has(plugin.name))
+    const selectedPlugins = allPlugins.filter(plugin => selectedKeys.has(plugin.name))
 
     // 准备卸载参数
     const params: PluginAdminParams = {
@@ -307,7 +251,7 @@ export const PluginManagePage = (): ReactElement => {
 
     // 使用通用处理函数
     handlePluginOperation(params)
-  }, [plugins, selectedKeys, handlePluginOperation])
+  }, [allPlugins, selectedKeys, handlePluginOperation])
 
   /**
    * 处理单个插件更新
@@ -383,43 +327,6 @@ export const PluginManagePage = (): ReactElement => {
   }, [handlePluginOperation, setUpdateModalOpen])
 
   /**
-   * 计算每种类型的插件数量
-   */
-  const getPluginCounts = useCallback(() => {
-    if (!allPlugins || allPlugins.length === 0) return { all: 0, npm: 0, git: 0, app: 0 }
-
-    // 初始化总数为0，不再包含all
-    const counts = { all: 0, npm: 0, git: 0, app: 0 }
-
-    // 先统计每种类型的数量
-    allPlugins.forEach(plugin => {
-      const pluginType = plugin.type as keyof typeof counts
-      if (pluginType in counts) {
-        counts[pluginType]++
-      }
-    })
-
-    // 然后计算总数
-    counts.all = allPlugins.length
-
-    return counts
-  }, [allPlugins])
-
-  /**
-   * 渲染筛选卡片
-   */
-  const renderFilterCards = () => {
-    const counts = getPluginCounts()
-    return (
-      <FilterCards
-        counts={counts}
-        selectedType={selectedType}
-        onTypeChange={handleTypeChange}
-      />
-    )
-  }
-
-  /**
    * 渲染表格内容
    */
   const renderTableContent = () => {
@@ -436,7 +343,7 @@ export const PluginManagePage = (): ReactElement => {
     }
 
     // 如果是空结果且正在延迟显示，同样显示加载中状态
-    if (plugins.length === 0 && delayEmptyResult) {
+    if (allPlugins.length === 0 && delayEmptyResult) {
       return (
         <div className='flex items-center justify-center h-60 bg-default-100/30 dark:bg-default-200/10 backdrop-blur-sm rounded-xl shadow-sm'>
           <div className='flex flex-col items-center gap-3'>
@@ -460,11 +367,11 @@ export const PluginManagePage = (): ReactElement => {
     }
 
     // 对于小数据量，自动跳过LazyPluginLoader的分批加载
-    const skipLazyLoading = plugins.length <= 30
+    const skipLazyLoading = allPlugins.length <= 30
 
     return (
       <TableContent
-        plugins={plugins}
+        plugins={allPlugins}
         loading={false} // 完全禁用TableContent内部的加载状态
         selectedMap={selectedMap}
         rowHeight={rowHeight}
@@ -484,54 +391,45 @@ export const PluginManagePage = (): ReactElement => {
   }
 
   return (
-    <div className='w-full p-5'>
-      <div className='flex flex-col sm:flex-row justify-between items-start sm:items-center mb-8'>
-        <div className='flex items-center gap-2 mb-4 sm:mb-0'>
-          <MdOutlineExtension className='text-2xl text-default-600' />
-          <h1 className='text-2xl font-semibold text-default-700'>插件管理</h1>
-        </div>
-        <div className='flex gap-3 justify-center w-full sm:w-auto sm:self-auto'>
-          {/* 全选按钮已移除，改由表头复选框处理全选和取消全选功能 */}
-          <Button
-            color='success'
-            size='sm'
-            variant='flat'
-            className='glass-effect'
-            radius='full'
-            startContent={<TbArrowsUp className='text-lg' />}
-            isDisabled={(selectedType !== 'all' && getSelectedCount() === 0) || (!plugins || plugins.length === 0)}
-            onPress={selectedType === 'all' && getSelectedCount() === 0 ? handleUpdateAll : handleUpdateSelected}
-          >
-            {selectedType === 'all' && getSelectedCount() === 0 ? '更新全部' : '更新选中'}
-          </Button>
-          <Button
-            color='danger'
-            size='sm'
-            variant='flat'
-            className='glass-effect'
-            radius='full'
-            startContent={<TbTrash className='text-lg' />}
-            isDisabled={getSelectedCount() === 0}
-            onPress={handleUninstallSelected}
-          >
-            卸载选中
-          </Button>
-          <Button
-            color='primary'
-            size='sm'
-            variant='flat'
-            className='glass-effect'
-            radius='full'
-            startContent={<TbRefresh className='text-lg' />}
-            isLoading={loading}
-            onPress={fetchPlugins}
-          >
-            刷新
-          </Button>
-        </div>
+    <div>
+      <div className='flex gap-3 justify-end mb-4'>
+        <Button
+          color='success'
+          size='sm'
+          variant='flat'
+          className='glass-effect'
+          radius='full'
+          startContent={<TbArrowsUp className='text-lg' />}
+          isDisabled={getSelectedCount() === 0 || (!allPlugins || allPlugins.length === 0)}
+          onPress={getSelectedCount() === 0 ? handleUpdateAll : handleUpdateSelected}
+        >
+          {getSelectedCount() === 0 ? '更新全部' : '更新选中'}
+        </Button>
+        <Button
+          color='danger'
+          size='sm'
+          variant='flat'
+          className='glass-effect'
+          radius='full'
+          startContent={<TbTrash className='text-lg' />}
+          isDisabled={getSelectedCount() === 0}
+          onPress={handleUninstallSelected}
+        >
+          卸载选中
+        </Button>
+        <Button
+          color='primary'
+          size='sm'
+          variant='flat'
+          className='glass-effect'
+          radius='full'
+          startContent={<TbRefresh className='text-lg' />}
+          isLoading={remoteLoading}
+          onPress={fetchPlugins}
+        >
+          刷新
+        </Button>
       </div>
-
-      {renderFilterCards()}
 
       {renderTableContent()}
 
@@ -559,4 +457,4 @@ export const PluginManagePage = (): ReactElement => {
   )
 }
 
-export default PluginManagePage
+export default LocalPlugin

--- a/packages/web/src/components/plugin/index/LocalPluginCard.tsx
+++ b/packages/web/src/components/plugin/index/LocalPluginCard.tsx
@@ -1,0 +1,159 @@
+import { Link } from '@heroui/link'
+import { Chip } from '@heroui/chip'
+import { Avatar } from '@heroui/avatar'
+import { FaUser } from 'react-icons/fa6'
+import { Tooltip } from '@heroui/tooltip'
+import { Card, CardBody } from '@heroui/card'
+import { FaCheckCircle } from 'react-icons/fa'
+
+import type { FC } from 'react'
+import type { FrontendInstalledPluginListResponse } from 'node-karin'
+
+/**
+ * 已安装图标组件
+ * @returns 返回已安装图标组件
+ */
+const InstalledIcon: FC = () => {
+  return (
+    <Tooltip content='已安装'>
+      <div className='flex items-center justify-center'>
+        <FaCheckCircle className='text-success text-sm' />
+      </div>
+    </Tooltip>
+  )
+}
+
+/**
+ * 插件名称组件
+ * @param plugin - 插件信息
+ * @returns 返回插件名称组件
+ */
+const PluginName: FC<{ plugin: FrontendInstalledPluginListResponse }> = ({ plugin }) => {
+  if (plugin.repoUrl) {
+    return (
+      <Tooltip content='点击访问插件主页'>
+        <Link
+          href={plugin.repoUrl}
+          isExternal
+          className='text-sm font-medium text-default-900 hover:text-primary-500 transition-colors truncate'
+        >
+          {plugin.name}
+        </Link>
+      </Tooltip>
+    )
+  }
+
+  return (
+    <span className='text-sm font-medium text-default-900 truncate'>{plugin.name}</span>
+  )
+}
+
+/**
+ * 插件描述组件
+ * @param plugin - 插件信息
+ * @returns 返回插件描述组件
+ */
+const PluginDescription: FC<{ plugin: FrontendInstalledPluginListResponse }> = ({ plugin }) => {
+  const description = plugin.description || '暂无描述'
+
+  return (
+    <p className='text-xs text-default-500 line-clamp-2 break-words'>
+      {description}
+    </p>
+  )
+}
+
+/**
+ * 卡片头像组件
+ * @param plugin - 插件信息
+ * @returns 返回卡片头像组件
+ */
+const CardAvatar: FC<{ plugin: FrontendInstalledPluginListResponse }> = ({ plugin }) => {
+  if (!plugin.author) {
+    return (
+      <Avatar
+        isBordered
+        size='sm'
+        icon={<FaUser />}
+        className='bg-default-100 border-white dark:border-default-800'
+      />
+    )
+  }
+
+  return (
+    <Tooltip
+      content={
+        <div className='text-center'>
+          <p className='text-sm text-default-600'>{plugin.author.name}</p>
+          {plugin.author.home && <p className='text-xs text-default-400'>点击访问主页</p>}
+        </div>
+      }
+    >
+      {plugin.author.home
+        ? (
+          <Link href={plugin.author.home} isExternal>
+            <Avatar
+              isBordered
+              size='sm'
+              src={plugin.author.avatar || `https://avatar.vercel.sh/${plugin.author.name}`}
+              className='bg-default-100 border-white dark:border-default-800'
+            />
+          </Link>
+        )
+        : (
+          <Avatar
+            isBordered
+            size='sm'
+            src={plugin.author.avatar || `https://avatar.vercel.sh/${plugin.author.name}`}
+            className='bg-default-100 border-white dark:border-default-800'
+          />
+        )}
+    </Tooltip>
+  )
+}
+
+/**
+ * 简洁版已安装插件卡片组件
+ * @param plugin - 插件信息
+ * @returns 返回插件卡片组件
+ */
+const InstalledPluginCard: FC<{
+  plugin: FrontendInstalledPluginListResponse
+}> = ({ plugin }) => {
+  return (
+    <Card
+      className='w-full flex flex-col overflow-hidden bg-default-50/10 rounded-xl border border-default-200 transition-all duration-300 hover:border-primary-500 hover:shadow-sm'
+      radius='sm'
+    >
+      <CardBody className='p-4'>
+        <div className='flex items-start justify-between gap-3 mb-2'>
+          <div className='flex-1 min-w-0'>
+            <div className='flex items-center gap-2 mb-1.5'>
+              <InstalledIcon />
+              <PluginName plugin={plugin} />
+            </div>
+            <PluginDescription plugin={plugin} />
+          </div>
+
+          <div className='flex shrink-0'>
+            <CardAvatar plugin={plugin} />
+          </div>
+        </div>
+
+        <div className='flex items-center mt-auto'>
+          <Chip
+            variant='flat'
+            size='sm'
+            className='h-5 px-2 bg-default-100/80 border-small border-default-200/50'
+          >
+            <span className='text-xs font-mono'>
+              {plugin.type}
+            </span>
+          </Chip>
+        </div>
+      </CardBody>
+    </Card>
+  )
+}
+
+export default InstalledPluginCard

--- a/packages/web/src/components/plugin/index/PluginCard.tsx
+++ b/packages/web/src/components/plugin/index/PluginCard.tsx
@@ -1,0 +1,115 @@
+import {
+  LuPackage,
+  LuPlug,
+  LuGlobe,
+  LuDownload,
+} from 'react-icons/lu'
+import { useNavigate } from 'react-router-dom'
+import { BasicCard } from '@/components/card'
+import { useState } from 'react'
+
+/**
+ * 渲染图标
+ */
+const renderIcon = (size: number, largeSize: number, Icon: typeof LuPackage) => (
+  <>
+    <Icon size={size} className='md:hidden' />
+    <Icon size={largeSize} className='hidden md:block' />
+  </>
+)
+
+const useSmartNavigate = () => {
+  const navigate = useNavigate()
+  const [isNavigating, setIsNavigating] = useState<Record<string, boolean>>({})
+
+  const handleNavigation = (path: string) => {
+    if (isNavigating[path]) return
+    /** 设置导航状态 */
+    setIsNavigating(prev => ({ ...prev, [path]: true }))
+
+    /** 增加小延迟提供更好的视觉反馈 */
+    setTimeout(() => {
+      navigate(path)
+      setIsNavigating(prev => ({ ...prev, [path]: false }))
+    }, 150)
+  }
+
+  return { handleNavigation, isNavigating }
+}
+
+/**
+ * 插件索引 头部卡片组件
+ */
+const PluginAdminCard = () => {
+  const { handleNavigation, isNavigating } = useSmartNavigate()
+
+  return (
+    <>
+      {/* 信息统计卡片 */}
+      <div className='grid grid-cols-1 sm:grid-cols-4 gap-2 md:gap-4 mt-4 md:mt-6'>
+        {/* 插件市场卡片 */}
+        <BasicCard
+          title='插件市场'
+          description='浏览和安装新插件'
+          icon={renderIcon(16, 20, LuPlug)}
+          gradient='bg-gradient-to-br from-green-50 to-green-100 dark:from-green-900/20 dark:to-green-800/20'
+          border='border border-green-200/50 dark:border-green-800/30'
+          iconBg='bg-green-100 dark:bg-green-700/30'
+          textColor='text-green-600 dark:text-green-400'
+          ringColor='ring-green-400 dark:ring-green-500'
+          isActive={isNavigating['/plugins/list']}
+          onClick={() => handleNavigation('/plugins/list')}
+          tooltip='访问插件市场，浏览和安装新插件'
+        />
+
+        {/* 依赖管理卡片 */}
+        <BasicCard
+          title='依赖管理'
+          description='管理系统依赖'
+          icon={renderIcon(16, 20, LuPackage)}
+          gradient='bg-gradient-to-br from-blue-50 to-blue-100 dark:from-blue-900/20 dark:to-blue-800/20'
+          border='border border-blue-200/50 dark:border-blue-800/30'
+          iconBg='bg-blue-100 dark:bg-blue-700/30'
+          textColor='text-blue-600 dark:text-blue-400'
+          ringColor='ring-blue-400 dark:ring-blue-500'
+          isActive={isNavigating['/dependencies']}
+          onClick={() => handleNavigation('/dependencies')}
+          tooltip='管理系统依赖和npm库'
+        />
+
+        {/* 已安装卡片 */}
+        <BasicCard
+          title='已安装'
+          description='管理已安装插件'
+          icon={renderIcon(16, 20, LuDownload)}
+          gradient='bg-gradient-to-br from-amber-50 to-amber-100 dark:from-amber-900/20 dark:to-amber-800/20'
+          border='border border-amber-200/50 dark:border-amber-800/30'
+          iconBg='bg-amber-100 dark:bg-amber-700/30'
+          textColor='text-amber-600 dark:text-amber-400'
+          ringColor='ring-amber-400 dark:ring-amber-500'
+          isActive={isNavigating['/plugins/manage']}
+          onClick={() => handleNavigation('/plugins/manage')}
+          tooltip='查看和管理已安装的插件'
+        />
+
+        {/* WebUI插件卡片 */}
+        <BasicCard
+          title='WebUI插件'
+          description='管理WebUI插件'
+          icon={renderIcon(16, 20, LuGlobe)}
+          gradient='bg-gradient-to-br from-purple-50 to-purple-100 dark:from-purple-900/20 dark:to-purple-800/20'
+          border='border border-purple-200/50 dark:border-purple-800/30'
+          iconBg='bg-purple-100 dark:bg-purple-700/30'
+          textColor='text-purple-600 dark:text-purple-400'
+          ringColor='ring-purple-400 dark:ring-purple-500'
+          isActive={isNavigating['/plugins/webui']}
+          onClick={() => handleNavigation('/plugins/webui')}
+          tooltip='管理网页控制台相关插件'
+        />
+
+      </div>
+    </>
+  )
+}
+
+export default PluginAdminCard

--- a/packages/web/src/components/plugin/index/card.tsx
+++ b/packages/web/src/components/plugin/index/card.tsx
@@ -1,0 +1,252 @@
+import { Link } from '@heroui/link'
+import { Chip } from '@heroui/chip'
+import { Avatar } from '@heroui/avatar'
+import { FaUser } from 'react-icons/fa6'
+import { Tooltip } from '@heroui/tooltip'
+import { BadgeCheck } from 'lucide-react'
+import { Card, CardBody } from '@heroui/card'
+
+import type { FC } from 'react'
+import type { FrontendInstalledPluginListResponse } from 'node-karin'
+
+/**
+ * 卡片安装图标组件
+ * @param installed - 是否已安装
+ * @param onClick - 点击事件
+ * @returns 返回卡片安装图标组件
+ */
+const IsInstallIcon: FC<{
+  installed: boolean
+  onClick?: () => void
+}> = ({ installed }) => {
+  if (installed) {
+    return (
+      <Tooltip content='已安装'>
+        <div className='relative flex items-center justify-center'>
+          <div className='w-4 h-4 flex items-center justify-center'>
+            <BadgeCheck className='w-full h-full text-success-500/90 dark:text-success-400/90 stroke-[2]' />
+          </div>
+        </div>
+      </Tooltip>
+    )
+  }
+  return <></>
+}
+
+/**
+ * 插件名称组件
+ * @param plugin - 插件信息
+ * @returns 返回插件名称组件
+ */
+const PluginName: FC<{ plugin: FrontendInstalledPluginListResponse }> = ({ plugin }) => {
+  if (plugin.repoUrl) {
+    return (
+      <Tooltip content='点击访问插件主页'>
+        <Link
+          href={plugin.repoUrl}
+          isExternal
+          className='text-sm font-medium text-default-900 hover:text-primary-500 transition-colors truncate'
+        >
+          {plugin.id}
+        </Link>
+      </Tooltip>
+    )
+  }
+
+  return (
+    <span className='text-sm font-medium text-default-900 truncate'>{plugin.id}</span>
+  )
+}
+
+/**
+ * 插件描述组件
+ * @param plugin - 插件信息
+ * @returns 返回插件描述组件
+ */
+const PluginDescription: FC<{ plugin: FrontendInstalledPluginListResponse }> = ({ plugin }) => {
+  const getDefaultDescription = (name: string) => {
+    const descriptions = [
+      '为您的工作流程带来更多可能性和效率提升',
+      '简单易用且功能强大的插件，助力开发体验',
+      '为项目开发锦上添花的得力助手',
+      '提升开发效率的智能工具，让工作更轻松',
+      '优化您的开发流程，提供更好的使用体验',
+      '为您的项目增添新的维度和可能性',
+      '智能且高效的开发工具，助力效率提升',
+      '让开发更简单，让创作更有趣',
+      '为您的工作流程带来智能化的解决方案',
+      '提供专业的开发支持，让工作更高效',
+    ]
+
+    /** 种子 */
+    const seed = name.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
+    /** 索引 */
+    const index = seed % descriptions.length
+
+    /** 将插件名称插入描述中，使其更加个性化 */
+    return descriptions[index].replace(/您的|开发/, () => {
+      const keywords = ['您的', name, '开发']
+      return keywords[seed % keywords.length]
+    })
+  }
+
+  /**
+   * 截断文本并添加省略号
+   * @param text - 需要截断的文本
+   * @param maxLength - 最大长度
+   * @returns 截断后的文本
+   */
+  const truncateText = (text: string): string => {
+    /** 一行大约可显示的字符数 */
+    const charsPerLine = 40
+    /** 两行最多可显示的字符数 */
+    const maxChars = charsPerLine * 2
+
+    if (text.length <= maxChars) {
+      return text
+    }
+
+    /** 在合适的位置截断，优先在标点符号或空格处 */
+    let truncateIndex = maxChars
+    /** 从最大长度向前查找适合的截断位置（标点符号或空格） */
+    for (let i = maxChars; i > maxChars - 10; i--) {
+      if ([',', '.', '，', '。', '；', ';', ' ', '、'].includes(text[i])) {
+        truncateIndex = i + 1
+        break
+      }
+    }
+
+    return text.substring(0, truncateIndex) + '...'
+  }
+
+  const description = !plugin.description
+    ? getDefaultDescription(plugin.id)
+    : plugin.description
+
+  /** 处理可能过长的描述 */
+  const displayText = truncateText(description)
+
+  return (
+    <p className='text-xs text-default-500 line-clamp-2 leading-relaxed' title={description}>
+      {displayText}
+    </p>
+  )
+}
+
+/**
+ * 卡片头像组件
+ * @param plugin - 插件信息
+ * @returns 返回卡片头像组件
+ */
+const CardAvatar: FC<{ plugin: FrontendInstalledPluginListResponse }> = ({ plugin }) => {
+  if (!plugin.author) {
+    return (
+      <Avatar
+        isBordered
+        size='sm'
+        icon={<FaUser />}
+        className='bg-default-100 border-white dark:border-default-800'
+      />
+    )
+  }
+
+  return (
+    <Tooltip
+      content={
+        <div className='text-center'>
+          <p className='text-sm text-default-600'>{plugin.author.name}</p>
+          {
+            plugin.author.home &&
+            (
+              <p className='text-xs text-default-400'>点击访问主页</p>
+            )
+          }
+        </div>
+      }
+    >
+      {plugin.author.home
+        ? (
+          <Link href={plugin.author.home} isExternal>
+            <Avatar
+              isBordered
+              size='sm'
+              src={plugin.author.avatar || 'https://avatar.vercel.sh/ikenxuan'}
+              className='bg-default-100 border-white dark:border-default-800'
+            />
+          </Link>
+        )
+        : (
+          <Avatar
+            isBordered
+            size='sm'
+            src={plugin.author.avatar || 'https://avatar.vercel.sh/ikenxuan'}
+            className='bg-default-100 border-white dark:border-default-800'
+          />
+        )}
+    </Tooltip>
+  )
+}
+
+/**
+ * 插件卡片组件
+ * @param plugin - 插件信息
+ * @param cardClassName - 可选，外部自定义卡片className
+ * @returns 返回插件卡片组件
+ */
+const PluginCard: FC<{
+  plugin: FrontendInstalledPluginListResponse,
+  cardClassName?: string
+}> = ({ plugin, cardClassName }) => {
+  return (
+    <Card
+      className={`group w-full h-[140px] flex flex-col overflow-hidden cursor-pointer relative bg-default-50/10 rounded-xl border border-default-200 transition-all duration-700 hover:border-primary-500 hover:shadow-sm hover:shadow-primary-500/50 hover:scale-[1.02] ${cardClassName || ''}`}
+      isPressable
+      radius='sm'
+      style={{
+        '--tw-border-opacity': '0.6',
+        transition: 'border-color 0.7s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.5s cubic-bezier(0.4, 0, 0.2, 1), transform 0.1s ease-out',
+      } as React.CSSProperties}
+    >
+      <CardBody className='p-4 flex flex-col h-full relative'>
+        <div className='flex items-start justify-between gap-3 mb-2'>
+          <div className='flex-1 min-w-0'>
+            <div className='flex items-center gap-2 mb-1.5'>
+              <IsInstallIcon installed />
+              <PluginName plugin={plugin} />
+            </div>
+            <PluginDescription plugin={plugin} />
+          </div>
+
+          <div className='flex shrink-0'>
+            <CardAvatar plugin={plugin} />
+          </div>
+        </div>
+
+        <div className='flex items-center justify-between mt-auto'>
+          <div className='flex items-center gap-2'>
+            <Chip
+              variant='flat'
+              size='sm'
+              className='h-5 px-2 bg-default-100/80 border-small border-default-200/50'
+            >
+              {/* {plugin.version
+                ? (
+                  <span className='text-xs font-mono'>
+                    {`v${plugin.version}`}
+                  </span>
+                )
+                : (
+                  <span className='text-xs font-mono'>
+                    ⁄(⁄ ⁄•⁄ω⁄•⁄ ⁄)⁄
+                  </span>
+                )} */}
+            </Chip>
+            {/* {plugin.type === 'npm' && <NpmInfo name={plugin.id} isRefreshing={isRefreshing} />} */}
+          </div>
+        </div>
+      </CardBody>
+    </Card>
+  )
+}
+
+export default PluginCard

--- a/packages/web/src/components/plugin/index/card.tsx
+++ b/packages/web/src/components/plugin/index/card.tsx
@@ -5,6 +5,8 @@ import { FaUser } from 'react-icons/fa6'
 import { Tooltip } from '@heroui/tooltip'
 import { BadgeCheck } from 'lucide-react'
 import { Card, CardBody } from '@heroui/card'
+import { Button } from '@heroui/button'
+import { IoSettingsOutline } from 'react-icons/io5'
 
 import type { FC } from 'react'
 import type { FrontendInstalledPluginListResponse } from 'node-karin'
@@ -197,6 +199,11 @@ const PluginCard: FC<{
   plugin: FrontendInstalledPluginListResponse,
   cardClassName?: string
 }> = ({ plugin, cardClassName }) => {
+  /** 处理配置按钮点击 */
+  const handleConfigClick = () => {
+    console.log('配置插件:', plugin.id)
+  }
+
   return (
     <Card
       className={`group w-full h-[140px] flex flex-col overflow-hidden cursor-pointer relative bg-default-50/10 rounded-xl border border-default-200 transition-all duration-700 hover:border-primary-500 hover:shadow-sm hover:shadow-primary-500/50 hover:scale-[1.02] ${cardClassName || ''}`}
@@ -224,25 +231,42 @@ const PluginCard: FC<{
 
         <div className='flex items-center justify-between mt-auto'>
           <div className='flex items-center gap-2'>
-            <Chip
-              variant='flat'
-              size='sm'
-              className='h-5 px-2 bg-default-100/80 border-small border-default-200/50'
-            >
-              {/* {plugin.version
-                ? (
-                  <span className='text-xs font-mono'>
-                    {`v${plugin.version}`}
-                  </span>
-                )
-                : (
+            {plugin.hasConfig
+              ? (
+                <Chip
+                  variant='flat'
+                  size='sm'
+                  className='h-5 px-2 bg-blue-100/80 border-small border-blue-200/50 text-blue-700'
+                >
+                  <span className='text-xs'>可配置</span>
+                </Chip>
+              )
+              : (
+                <Chip
+                  variant='flat'
+                  size='sm'
+                  className='h-5 px-2 bg-default-100/80 border-small border-default-200/50'
+                >
                   <span className='text-xs font-mono'>
                     ⁄(⁄ ⁄•⁄ω⁄•⁄ ⁄)⁄
                   </span>
-                )} */}
-            </Chip>
-            {/* {plugin.type === 'npm' && <NpmInfo name={plugin.id} isRefreshing={isRefreshing} />} */}
+                </Chip>
+              )}
           </div>
+
+          {plugin.hasConfig && (
+            <Button
+              isIconOnly
+              size='sm'
+              variant='light'
+              color='primary'
+              aria-label='配置插件'
+              className='p-1'
+              onPress={handleConfigClick}
+            >
+              <IoSettingsOutline className='text-lg' />
+            </Button>
+          )}
         </div>
       </CardBody>
     </Card>

--- a/packages/web/src/components/plugin/index/card.tsx
+++ b/packages/web/src/components/plugin/index/card.tsx
@@ -7,6 +7,7 @@ import { BadgeCheck } from 'lucide-react'
 import { Card, CardBody } from '@heroui/card'
 import { Button } from '@heroui/button'
 import { IoSettingsOutline } from 'react-icons/io5'
+import { useNavigate } from 'react-router-dom'
 
 import type { FC } from 'react'
 import type { FrontendInstalledPluginListResponse } from 'node-karin'
@@ -199,9 +200,14 @@ const PluginCard: FC<{
   plugin: FrontendInstalledPluginListResponse,
   cardClassName?: string
 }> = ({ plugin, cardClassName }) => {
+  const navigate = useNavigate()
+
   /** 处理配置按钮点击 */
   const handleConfigClick = () => {
-    console.log('配置插件:', plugin.id)
+    /** 增加小延迟提供更好的视觉反馈 */
+    setTimeout(() => {
+      navigate(`/plugins/config?name=${plugin.id}`)
+    }, 150)
   }
 
   return (

--- a/packages/web/src/components/plugin/index/index.ts
+++ b/packages/web/src/components/plugin/index/index.ts
@@ -1,0 +1,5 @@
+export { default as PluginAdminCard } from './PluginCard'
+export { default as LoadingState } from './LoadingState'
+export { default as LocalPlugin } from './LocalPlugin'
+export { default as LocalPluginCard } from './LocalPluginCard'
+export { default as LocalPluginList } from './Local'

--- a/packages/web/src/config/site.ts
+++ b/packages/web/src/config/site.ts
@@ -4,13 +4,9 @@ import { BsInfoCircleFill } from 'react-icons/bs'
 import {
   MdSpaceDashboard,
   MdExtension,
-  MdStore,
   MdOutlineArticle, // 系统日志
   MdOutlineTerminal, // 仿真终端
-  MdSystemUpdate, // 插件/卸载
-  MdWeb, // 插件管理
 } from 'react-icons/md'
-import { TbPackages } from 'react-icons/tb' // 依赖管理图标
 
 import type { LocalApiResponse } from 'node-karin'
 
@@ -58,42 +54,9 @@ export const defaultSiteConfig: SiteConfigType = {
       href: '/config',
     },
     {
-      Icon: MdExtension, // 改为插件图标
+      Icon: MdExtension,
       label: '插件管理',
-      href: '/plugins-management',
-      children: [
-        {
-          id: 'plugin-config',
-          href: '/plugins',
-          label: '配置',
-          Icon: RiSettings2Fill, // 保持设置图标
-          children: [],
-        },
-        {
-          id: 'plugin-market',
-          href: '/plugins/list',
-          label: '市场',
-          Icon: MdStore, // 保持商店图标
-        },
-        {
-          id: 'plugin-manage',
-          href: '/plugins/manage',
-          label: '更新/卸载',
-          Icon: MdSystemUpdate, // 改为系统更新图标
-        },
-        {
-          id: 'dependencies',
-          href: '/dependencies',
-          label: '依赖管理',
-          Icon: TbPackages, // 保持包管理图标
-        },
-        {
-          id: 'webui-plugins',
-          href: '/plugins/webui',
-          label: 'WebUI',
-          Icon: MdWeb, // 改为网页图标
-        },
-      ],
+      href: '/plugins-dashboard',
     },
     {
       Icon: MdOutlineTerminal,
@@ -130,16 +93,9 @@ const getInstalledPlugins = async () => {
 }
 
 /**
- * 初始化插件配置的三级菜单
+ * 初始化插件配置
  */
 export const initSiteConfig = async () => {
-  const plugins = await getInstalledPlugins()
-  const pluginManagementIndex = siteConfig.navItems.findIndex(item => item.href === '/plugins-management')
-  if (pluginManagementIndex !== -1) {
-    const pluginConfigIndex = siteConfig.navItems[pluginManagementIndex].children?.findIndex(item => item.id === 'plugin-config')
-    if (pluginConfigIndex !== undefined && pluginConfigIndex !== -1 && siteConfig.navItems[pluginManagementIndex].children) {
-      // 将插件列表添加到"配置"的子菜单中
-      siteConfig.navItems[pluginManagementIndex].children[pluginConfigIndex].children = plugins
-    }
-  }
+  // 插件列表现在将直接在插件概览页面中使用，不再添加到侧边栏
+  await getInstalledPlugins()
 }

--- a/packages/web/src/pages/dashboard/dependencies/dependencies.tsx
+++ b/packages/web/src/pages/dashboard/dependencies/dependencies.tsx
@@ -229,7 +229,6 @@ export default function DependenciesPage () {
     <>
       {/* 总依赖数卡片 */}
       <StatCard
-        title='总依赖'
         count={stats.total}
         description={isRealTimeData ? '总依赖数 (实时数据)' : '总依赖数 (当前页面的依赖均为缓存)'}
         icon={renderIcon(16, 20, LuPackage)}
@@ -244,7 +243,6 @@ export default function DependenciesPage () {
 
       {/* Karin插件卡片 */}
       <StatCard
-        title='Karin插件'
         count={stats.plugins}
         description='Karin 插件'
         icon={renderIcon(16, 20, LuPackage)}
@@ -260,7 +258,6 @@ export default function DependenciesPage () {
 
       {/* 可更新卡片 */}
       <StatCard
-        title='可更新'
         count={stats.updatable}
         description='可更新'
         icon={renderIcon(16, 20, LuDownload)}

--- a/packages/web/src/pages/dashboard/plugins-dashboard.tsx
+++ b/packages/web/src/pages/dashboard/plugins-dashboard.tsx
@@ -1,0 +1,42 @@
+import { LuPackage, LuDownload } from 'react-icons/lu'
+import { LocalPluginList, PluginAdminCard } from '@/components/plugin/index'
+
+/**
+ * 插件管理概览页面
+ */
+const PluginsDashboard = () => {
+  return (
+    <div className='w-full p-4 sm:p-6 md:p-8'>
+      {/* 页面标题和操作按钮 */}
+      <div className='mb-6 md:mb-10'>
+        <div className='flex flex-wrap items-start justify-between gap-3 md:gap-6'>
+          <div className='flex flex-col'>
+            <h1 className='text-2xl md:text-3xl font-light text-foreground/90 tracking-tight flex items-center gap-2'>
+              <LuPackage size={24} className='text-primary-500' />
+              插件索引
+            </h1>
+            <p className='text-sm md:text-base text-default-500 mt-0.5 md:mt-1'>
+              ✨ 欢迎来到插件小屋～在这里轻松发现并管理你的所有插件！
+            </p>
+          </div>
+        </div>
+
+      </div>
+
+      {/* 插件索引 头部卡片组件 */}
+      <PluginAdminCard />
+
+      {/* 插件列表 */}
+      <h3 className='mt-10 text-2xl md:text-3xl font-light text-foreground/90 tracking-tight flex items-center gap-2'>
+        <LuDownload size={24} className='text-primary-500' />
+        已安装插件
+      </h3>
+      <div className='space-y-4 mt-4'>
+        {/* 搜索和过滤区域可以在这里添加 */}
+        <LocalPluginList />
+      </div>
+    </div>
+  )
+}
+
+export default PluginsDashboard

--- a/packages/web/src/pages/dashboard/plugins/config.tsx
+++ b/packages/web/src/pages/dashboard/plugins/config.tsx
@@ -11,7 +11,6 @@ import type { GetConfigResponse } from 'node-karin'
 
 interface GetConfigRequest {
   name: string
-  type: 'git' | 'npm' | 'app'
 }
 
 // http://localhost:5173/web/plugins/config?name=karin-plugin-demo&type=git
@@ -19,7 +18,6 @@ interface GetConfigRequest {
 export default function PluginConfigPage () {
   const [searchParams] = useSearchParams()
   const name = searchParams.get('name')
-  const type = searchParams.get('type') as GetConfigRequest['type'] | null
   const [config, setConfig] = useState<GetConfigResponse>({
     options: [],
     info: {
@@ -33,7 +31,7 @@ export default function PluginConfigPage () {
   const requestSentRef = useRef(false)
 
   const fetchConfig = useCallback(async () => {
-    if (!name || !type) return
+    if (!name) return
     // 如果已经发送过请求，则不再重复发送
     if (requestSentRef.current) return
 
@@ -45,7 +43,6 @@ export default function PluginConfigPage () {
         '/api/v1/plugin/config/get',
         {
           name,
-          type,
         }
       )
       setConfig(result)
@@ -55,19 +52,19 @@ export default function PluginConfigPage () {
     } finally {
       setLoading(false)
     }
-  }, [name, type])
+  }, [name])
 
   useEffect(() => {
-    if (!name || !type) return
+    if (!name) return
     fetchConfig()
 
     // 组件卸载时重置标记，以便在组件重新挂载时可以再次发送请求
     return () => {
       requestSentRef.current = false
     }
-  }, [name, type, fetchConfig])
+  }, [name, fetchConfig])
 
-  if (!name || !type) {
+  if (!name) {
     return (
       <Card className='max-w-lg mx-auto mt-8'>
         <CardBody>
@@ -117,5 +114,5 @@ export default function PluginConfigPage () {
     )
   }
 
-  return <DashboardPage options={config.options} info={{ ...config.info, type, id: config.info.id || name }} key={config.info.id || name} />
+  return <DashboardPage options={config.options} info={{ ...config.info, id: config.info.id || name }} key={config.info.id || name} />
 }

--- a/packages/web/src/request/base/api.ts
+++ b/packages/web/src/request/base/api.ts
@@ -41,4 +41,6 @@ export const api = {
 
   /** 重启karin */
   restartKarin: `${BASE_ROUTER}/restart`,
+  /** @version 1.10.0+ 获取前端已安装插件简约列表 */
+  getFrontendInstalledPluginList: `${BASE_ROUTER}/plugin/local/frontend`,
 }

--- a/packages/web/src/request/plugins/index.ts
+++ b/packages/web/src/request/plugins/index.ts
@@ -1,5 +1,6 @@
 import { api, request } from '@/request/base'
 import type {
+  FrontendInstalledPluginListResponse,
   LoadedPluginCacheList,
   PluginAdminListResponse,
   PluginAdminParams,
@@ -26,11 +27,19 @@ export const pluginAdminRequest = async (
 
 /**
  * 获取已安装插件名称列表
+ * @param isRefresh 是否强制刷新
  * @returns 已安装插件名称列表
  */
-export const getLocalPluginNameListRequest = async (): Promise<PluginAdminListResponse[]> => {
-  const response = await request.serverPost<PluginAdminListResponse[], null>(
-    api.getPluginListPluginAdmin
+export const getLocalPluginNameListRequest = async (
+  isRefresh: boolean = false
+): Promise<PluginAdminListResponse[]> => {
+  const response = await request.serverPost<PluginAdminListResponse[], {
+    isRefresh: boolean
+  }>(
+    api.getPluginListPluginAdmin,
+    {
+      isRefresh,
+    }
   )
   return response
 }
@@ -112,4 +121,19 @@ export interface CreateTaskResult {
   success: boolean
   /** 操作消息 */
   message?: string
+}
+
+/**
+ * 获取插件索引的简约插件列表
+ */
+export const getFrontendInstalledPluginListRequest = async (
+  forceRefresh = false
+): Promise<FrontendInstalledPluginListResponse[]> => {
+  const response = await request.serverPost<FrontendInstalledPluginListResponse[], {
+    forceRefresh: boolean
+  }>(
+    api.getFrontendInstalledPluginList,
+    { forceRefresh }
+  )
+  return response
 }

--- a/packages/web/src/request/plugins/index.ts
+++ b/packages/web/src/request/plugins/index.ts
@@ -127,13 +127,13 @@ export interface CreateTaskResult {
  * 获取插件索引的简约插件列表
  */
 export const getFrontendInstalledPluginListRequest = async (
-  forceRefresh = false
+  isRefresh = false
 ): Promise<FrontendInstalledPluginListResponse[]> => {
   const response = await request.serverPost<FrontendInstalledPluginListResponse[], {
-    forceRefresh: boolean
+    isRefresh: boolean
   }>(
     api.getFrontendInstalledPluginList,
-    { forceRefresh }
+    { isRefresh }
   )
   return response
 }


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构插件索引页面，全面改进服务器和客户端逻辑，引入专门的插件仪表盘，整合 API 端点并加入缓存，并创建新的可重用 UI 组件来管理和显示插件。

新特性：
- 在 `/plugins-dashboard` 引入新的插件仪表盘页面，其中包含概览卡片和已安装插件部分
- 添加 `GET_LOCAL_PLUGIN_FRONTEND_LIST` API 端点，用于获取前端安装插件的简洁列表
- 在插件列表请求中公开 `isRefresh` 选项，以控制 Redis 缓存行为

增强功能：
- 统一用于 git、npm 和 app 类型的服务器端插件列表处理程序，包含 web.config 元数据，并添加 Redis 缓存
- 集成 npm 注册表实用程序（`getNpmRegistry`、`getNpmLatestVersion`）并重构相关的实用程序和类型
- 扩展和重组插件响应和 npm 注册表数据的类型定义
- 简化前端插件列表请求并删除过时的合并逻辑
- 引入可重用 UI 组件（`BasicCard`、`LocalPluginList`、`PluginAdminCard`、`LoadingState`）并改进现有的 `StatCard` 属性

日常维护：
- 更新本地和前端插件列表的 Redis 键名和 TTL
- 删除已弃用的 npm 注册表获取逻辑和旧的基于依赖项的插件合并

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构插件索引页面，引入统一的仪表盘，改进服务器和客户端逻辑，并添加缓存和可重用的 UI 组件。

新特性：
- 在 `/plugins-dashboard` 添加一个新的插件仪表盘，包含概览卡片和已安装插件部分
- 公开一个 `GET_LOCAL_PLUGIN_FRONTEND_LIST` 端点，用于检索简化的前端插件列表
- 在插件列表 API 上支持 `isRefresh` 标志，以强制刷新 Redis 缓存

增强功能：
- 统一 git、npm 和 app 类型的服务器端插件列表处理程序，并使用 Redis 缓存
- 集成和重构 npm 注册表实用程序（`getNpmRegistry`、`getNpmLatestVersion`）并扩展相关的类型定义
- 在插件响应中将 `latestHash` 替换为 `latestVersion`，并嵌入 `webConfig` 元数据
- 通过删除已弃用的合并逻辑和过滤器卡片中冗余的标题来简化前端请求
- 引入可重用的 UI 组件（`BasicCard`、`PluginAdminCard`、`LocalPluginList`、`LoadingState`）并标准化 `StatCard` 属性
- 更新站点导航，通过新的仪表盘路由插件管理，并删除旧的侧边栏菜单

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the plugin index page to introduce a unified dashboard, improve server and client logic, and add caching and reusable UI components.

New Features:
- Add a new Plugins Dashboard at `/plugins-dashboard` with overview cards and an installed plugins section
- Expose a `GET_LOCAL_PLUGIN_FRONTEND_LIST` endpoint to retrieve a simplified frontend plugin list
- Support an `isRefresh` flag on plugin list APIs to force Redis cache refresh

Enhancements:
- Unify server-side plugin list handlers for git, npm, and app types with Redis caching
- Integrate and refactor npm registry utilities (`getNpmRegistry`, `getNpmLatestVersion`) and extend related type definitions
- Replace `latestHash` with `latestVersion` in plugin responses and embed `webConfig` metadata
- Simplify frontend requests by removing deprecated merge logic and redundant titles in filter cards
- Introduce reusable UI components (`BasicCard`, `PluginAdminCard`, `LocalPluginList`, `LoadingState`) and standardize `StatCard` props
- Update site navigation to route plugin management through the new dashboard and remove old sidebar menus

</details>

</details>