### PR TITLE
Fix: 修复lagrange环境下 调用getHistoryMsg只使用getGroupMsgHistory的问题

### DIFF
--- a/packages/core/src/adapter/onebot/core/core.ts
+++ b/packages/core/src/adapter/onebot/core/core.ts
@@ -370,7 +370,13 @@ export class AdapterOneBot<T extends OneBotType> extends AdapterBase {
 
 
       const seq = await this.getMsg(contact, startMsgId)
+      if (contact.scene === 'group') {
       return this._onebot.getGroupMsgHistory(Number(contact.peer), seq.message_seq, count)
+        } else if (contact.scene === 'friend') {
+      return this._onebot.getFriendMsgHistory(Number(contact.peer), seq.message_seq, count)
+        } else {
+      throw new Error(`不支持的消息环境:${contact.scene}`)
+      }
     })()
 
     return await Promise.all(result.messages.map(async (v) => {


### PR DESCRIPTION
只要使用的是 Lagrange.OneBot，并且 startMsgId 是 string 类型，它就会调用 lgl_getGroupMsgHistory

这个逻辑没有判断 contact.scene 是 'group' 还是 'friend'，这就是问题来源

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

为 Lagrange.OneBot 的 getHistoryMsg 方法添加场景感知处理，通过基于 contact.scene 调用适当的 API，并为不支持的场景抛出错误。

Bug 修复：
- 修复 Lagrange.OneBot 中的 getHistoryMsg，对群聊使用 `lgl_getGroupMsgHistory`，对好友聊天使用 `lgl_getFriendMsgHistory`
- 当 Lagrange.OneBot 的 getHistoryMsg 中 `contact.scene` 不是 'group' 或 'friend' 时抛出错误

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add scene-aware handling to the getHistoryMsg method for Lagrange.OneBot by calling the appropriate API based on contact.scene and throwing an error for unsupported scenes

Bug Fixes:
- Fix getHistoryMsg in Lagrange.OneBot to use lgl_getGroupMsgHistory for group chats and lgl_getFriendMsgHistory for friend chats
- Throw an error when contact.scene is not 'group' or 'friend' in Lagrange.OneBot getHistoryMsg

</details>