### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Thanks to [valqelyan](https://github.com/valqelyan) for transferring the `karin`
 ## 常见问题
 
 - 文档没看懂？[点我提问](https://github.com/KarinJS/Karin/issues) 或加群 967068507
-- 插件不会写？欢迎参考[插件开发文档](https://karinjs.com/plugins/)
+- 插件不会写？欢迎参考[插件开发文档](https://karinjs.com/guide/index/)
 - 遇到 bug？大胆提 Issue，我们超快响应！
 
 ## 如何参与贡献（PR）


### PR DESCRIPTION
页面 `https://karinjs.com/plugins/`不存在，跳转过去会是404

猜你想找：https://karinjs.com/guide/index/

## Sourcery 总结

文档：
- 更新插件开发文档 URL，使其指向指南索引而不是不存在的插件页面

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update plugin development documentation URL to point to the guide index instead of the nonexistent plugins page

</details>