### PR TITLE
生成文档的路径

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ lerna-debug.log*
 # 临时文件
 logs/
 /temp/
-packages/core/docs/guide/api/types/
+packages/core/guide/api/types/
 
 # 配置
 packages/core/plugins

--- a/packages/core/typedoc.config.js
+++ b/packages/core/typedoc.config.js
@@ -5,7 +5,7 @@ const config = {
     'src/index.ts',
   ],
   docsRoot: './',
-  out: './docs/guide/api/types',
+  out: './guide/api/types',
   theme: 'default',
   name: 'Karin API Docs',
   readme: '../../README.md',


### PR DESCRIPTION
## Sourcery 总结

改进：
- 调整 Typedoc 输出路径从 './docs/guide/api/types' 到 './guide/api/types'。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust Typedoc output path from './docs/guide/api/types' to './guide/api/types'.

</details>