### PR TITLE
fix: 更新依赖 兼容node18版本

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -166,7 +166,7 @@
     "chokidar": "4.0.3",
     "express": "npm:@karinjs/express@1.0.3",
     "lodash": "npm:@karinjs/lodash@1.1.1",
-    "log4js": "npm:@karinjs/log4js@1.5.4",
+    "log4js": "npm:@karinjs/log4js@1.5.6",
     "moment": "npm:@karinjs/moment@1.1.5",
     "node-schedule": "npm:@karinjs/node-schedule@1.0.0",
     "redis": "npm:@karinjs/redis@1.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: npm:@karinjs/lodash@1.1.1
         version: '@karinjs/lodash@1.1.1'
       log4js:
-        specifier: npm:@karinjs/log4js@1.5.4
-        version: '@karinjs/log4js@1.5.4'
+        specifier: npm:@karinjs/log4js@1.5.6
+        version: '@karinjs/log4js@1.5.6'
       moment:
         specifier: npm:@karinjs/moment@1.1.5
         version: '@karinjs/moment@1.1.5'
@@ -2046,8 +2046,8 @@ packages:
     resolution: {integrity: sha512-suq7TVHaaTrkD74WhEpzsm1SqZfiSf0yiWPEzoZhNbB1Kfwo/ys9yOwptZqTKXZyTghSrF+dfILvh2E32wBofw==}
     engines: {node: '>=18'}
 
-  '@karinjs/log4js@1.5.4':
-    resolution: {integrity: sha512-CXFAAjSOTBixq212fsV4N23T0jWJTGs829HU08amaC4KT7lbzC4FMSh6AFjtgbRh3lih690M07nhnBwa330QYQ==}
+  '@karinjs/log4js@1.5.6':
+    resolution: {integrity: sha512-BwLkG/TJLOvqe1cIpgLa+FGv5PJhQ/d+K+FRD4ELjHoU3jLd///lnbUwB0nTzIWSJyO+dJcrdHr87LGU2luOrw==}
     engines: {node: '>=18'}
 
   '@karinjs/moment@1.1.5':
@@ -8305,7 +8305,7 @@ snapshots:
 
   '@karinjs/lodash@1.1.1': {}
 
-  '@karinjs/log4js@1.5.4': {}
+  '@karinjs/log4js@1.5.6': {}
 
   '@karinjs/moment@1.1.5': {}
 


### PR DESCRIPTION
## Summary by Sourcery

增强内容：
- 在 core 包中将 `@karinjs/log4js` 依赖从 `1.5.4` 升级到 `1.5.6`，并刷新 pnpm 锁定文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Bump @karinjs/log4js dependency from 1.5.4 to 1.5.6 in the core package and refresh the pnpm lockfile.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a logging dependency to the latest patch version for improved stability and performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->