### PR TITLE
fix: 适配器信息添加 `protocolVersion`

### DIFF
--- a/packages/core/src/adapter/base/index.ts
+++ b/packages/core/src/adapter/base/index.ts
@@ -44,6 +44,7 @@ export abstract class AdapterBase<T = any> implements AdapterType<T> {
       platform: 'qq',
       standard: 'other',
       protocol: 'console',
+      protocolVersion: '',
       communication: 'other',
       address: '',
       secret: null,

--- a/packages/core/src/types/adapter/info.ts
+++ b/packages/core/src/types/adapter/info.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * 适配器所属平台
  * - `qq`: QQ
  * - `wechat`: 微信
@@ -87,8 +87,11 @@ export type AdapterCommunication = 'http'
   | 'other'
   | (string & {})
 
+// TODO: 太乱了，后续需要重新设计适配器信息结构，分为适配器基本信息和协议实现（或者协议SDK）信息两部分
 /**
  * 适配器基本信息
+ *
+ * TODO: 太乱了，后续需要重新设计适配器信息结构，分为适配器基本信息和协议实现（或者协议SDK）信息两部分
  */
 export interface AdapterInfo {
   /** 适配器索引 默认为-1 在注册适配器时会自动更改为对应的索引 */
@@ -103,6 +106,8 @@ export interface AdapterInfo {
   standard: AdapterStandard
   /** 适配器协议实现 如gocq、napcat */
   protocol: AdapterProtocol
+  /** 适配器协议实现版本 */
+  protocolVersion: string
   /** 适配器通信方式 */
   communication: AdapterCommunication
   /**


### PR DESCRIPTION
## Summary by Sourcery

在适配器信息中添加协议版本元数据，并在基础适配器实现中对其进行初始化。

新功能：
- 在适配器元数据中加入 `protocolVersion` 字段，用于描述适配器协议实现的版本。

改进：
- 记录未来重构意图：将适配器信息重组为基础信息和协议实现细节两部分。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add protocol version metadata to adapter information and initialize it in the base adapter implementation.

New Features:
- Include a protocolVersion field in adapter metadata to describe the adapter protocol implementation version.

Enhancements:
- Document future refactor intent to restructure adapter information into base info and protocol implementation details.

</details>