### PR TITLE
fix: 插件开发调用checkPkgUpdate判xxx插件未安装

### DIFF
--- a/packages/cli-Internal/src/build-dep.ts
+++ b/packages/cli-Internal/src/build-dep.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import yaml from 'yaml'
+import * as yaml from 'yaml'
 
 /**
  * 获取当前工作目录的 pnpm-workspace.yaml 文件路径

--- a/packages/cli-Internal/src/init.ts
+++ b/packages/cli-Internal/src/init.ts
@@ -9,7 +9,7 @@
  * 7. 创建基本配置文件
  */
 
-import yaml from 'yaml'
+import * as yaml from 'yaml'
 import fs from 'node:fs'
 import path from 'node:path'
 import { URL, fileURLToPath } from 'node:url'

--- a/packages/core/src/env/env/index.ts
+++ b/packages/core/src/env/env/index.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs'
-import yaml from 'yaml'
+import * as yaml from 'yaml'
 import { execSync } from 'node:child_process'
 
 let IS_PNPM10: boolean | null = null

--- a/packages/core/src/utils/fs/require.ts
+++ b/packages/core/src/utils/fs/require.ts
@@ -1,4 +1,4 @@
-import yaml from 'yaml'
+import * as yaml from 'yaml'
 import fs from 'node:fs'
 import path from 'node:path'
 

--- a/packages/core/src/utils/fs/yaml.ts
+++ b/packages/core/src/utils/fs/yaml.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import lodash from 'lodash'
-import YAML, { isMap, isSeq, isPair } from 'yaml'
+import { Document, parse, parseDocument, stringify, YAMLMap, YAMLSeq, isMap, isSeq, isPair } from 'yaml'
 
 export type YamlValue = string | boolean | number | object | any[]
 export type YamlComment = Record<string, string>
@@ -38,11 +38,11 @@ type Save = {
 /** YAML 编辑器 */
 export class YamlEditor {
   filePath: string
-  doc: YAML.Document
-  document: YAML.Document
+  doc: Document
+  document: Document
   constructor (file: string) {
     this.filePath = file
-    const data = YAML.parseDocument(fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : file)
+    const data = parseDocument(fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : file)
     this.doc = data
     this.document = data
   }
@@ -125,9 +125,9 @@ export class YamlEditor {
       const _path = typeof path === 'string' ? (isSplit ? path.split('.') : [path]) : path
       let current = this.document.getIn(_path)
       if (!current) {
-        current = new YAML.YAMLSeq()
+        current = new YAMLSeq()
         this.document.setIn(_path, current)
-      } else if (!(current instanceof YAML.YAMLSeq)) {
+      } else if (!(current instanceof YAMLSeq)) {
         logger.error('[YamlEditor] 指定的路径不是数组')
         return false
       } else {
@@ -155,7 +155,7 @@ export class YamlEditor {
         logger.error('[YamlEditor] 指定的路径不存在')
         return false
       }
-      if (!(current instanceof YAML.YAMLSeq)) {
+      if (!(current instanceof YAMLSeq)) {
         logger.error('[YamlEditor] 指定的路径不是数组')
         return false
       }
@@ -201,10 +201,10 @@ export class YamlEditor {
       if (!current) return false
 
       /** 检查当前节点是否包含指定的值 */
-      if (current instanceof YAML.YAMLSeq) {
+      if (current instanceof YAMLSeq) {
         /** 如果是序列，遍历序列查找值 */
         return current.items.some(item => lodash.isEqual(item.toJSON(), value))
-      } else if (current instanceof YAML.YAMLMap) {
+      } else if (current instanceof YAMLMap) {
         /** 如果是映射，检查每个值 */
         return Array.from((current as any).values()).some((v: any) => lodash.isEqual(v.toJSON(), value))
       } else {
@@ -233,9 +233,9 @@ export class YamlEditor {
    */
   pusharr (value: YamlValue): boolean {
     try {
-      if (!(this.document.contents instanceof YAML.YAMLSeq)) {
+      if (!(this.document.contents instanceof YAMLSeq)) {
         // 如果根节点不是数组，则将其转换为数组
-        this.document.contents = new YAML.YAMLSeq()
+        this.document.contents = new YAMLSeq()
         logger.debug('[YamlEditor] 根节点已转换为数组')
       }
       this.document.contents.add(value)
@@ -253,7 +253,7 @@ export class YamlEditor {
    */
   delarr (index: number): boolean {
     try {
-      if (!(this.document.contents instanceof YAML.YAMLSeq)) {
+      if (!(this.document.contents instanceof YAMLSeq)) {
         throw new Error('[YamlEditor] 根节点不是数组')
       }
       if (index < 0 || index >= this.document.contents.items.length) {
@@ -386,7 +386,7 @@ interface ReadFunction {
  * @returns 解析后的数据
  */
 export const read: ReadFunction = (path: string) => {
-  const data = YAML.parse(fs.readFileSync(path, 'utf-8'))
+  const data = parse(fs.readFileSync(path, 'utf-8'))
   /**
    * 保存数据并写入注释
    * @param options json路径或注释配置对象
@@ -411,7 +411,7 @@ export const read: ReadFunction = (path: string) => {
  */
 export const write = (path: string, value: any) => {
   try {
-    fs.writeFileSync(path, YAML.stringify(value))
+    fs.writeFileSync(path, stringify(value))
     return true
   } catch {
     return false
@@ -426,11 +426,11 @@ export const write = (path: string, value: any) => {
  */
 export const save: Save = (path: string, value: Record<string, any>, options?: string | YamlComment) => {
   if (!options) {
-    fs.writeFileSync(path, YAML.stringify(value))
+    fs.writeFileSync(path, stringify(value))
     return
   }
 
-  const editor = new YamlEditor(YAML.stringify(value))
+  const editor = new YamlEditor(stringify(value))
   const comment = typeof options === 'string'
     ? JSON.parse(fs.readFileSync(options, 'utf8')) as YamlComment
     : options
@@ -476,7 +476,16 @@ export const applyComments = (editor: YamlEditor, comments: YamlComment) => {
 }
 
 /** YAML 工具 */
-export const yaml = Object.assign(YAML, {
+export const yaml = {
+  parse,
+  stringify,
+  parseDocument,
+  Document,
+  YAMLSeq,
+  YAMLMap,
+  isMap,
+  isSeq,
+  isPair,
   /** 读取并解析 YAML 文件 */
   read,
   /** 保存数据并写入注释 */
@@ -485,4 +494,4 @@ export const yaml = Object.assign(YAML, {
   comment,
   /** 批量添加注释 */
   applyComments,
-})
+}

--- a/packages/core/src/utils/system/update.ts
+++ b/packages/core/src/utils/system/update.ts
@@ -229,11 +229,17 @@ export const getPkgVersion = async (name: string): Promise<string> => {
    * 2) 优先从 `npm list` 输出中解析完整语义化版本
    * 3) 若未安装或解析失败，兜底从 package.json 的依赖约束中提取语义化版本
    */
-  const pkg = await getPkg()
+  let pkg: Package | undefined
+  try {
+    pkg = await getPkg()
+  } catch {
+    pkg = undefined
+  }
+
   // 如果查询的就是当前项目自身，直接返回版本号
   // npm list 不会将项目自身视为已安装的依赖，会返回 (empty)，因此必须提前处理
   if (pkg?.name === name) {
-    return pkg.version || ''
+    return pkg?.version || ''
   }
 
   const { stdout, error } = await exec(`npm list ${name} --depth=0`)
@@ -249,6 +255,12 @@ export const getPkgVersion = async (name: string): Promise<string> => {
     }
   }
 
+  /** 兜底：使用 package.json 中的版本约束，提取语义化版本 */
+  const spec = pkg?.dependencies?.[name] || pkg?.devDependencies?.[name] || pkg?.peerDependencies?.[name]
+  if (spec) {
+    return extractSemver(spec) || spec
+  }
+
   if (error) {
     const stack = error?.stack?.toString() || ''
     if (stack.includes('empty')) {
@@ -257,10 +269,7 @@ export const getPkgVersion = async (name: string): Promise<string> => {
     throw error
   }
 
-  /** 兜底：使用 package.json 中的版本约束，提取语义化版本 */
-  const spec = pkg?.dependencies?.[name] || pkg?.devDependencies?.[name] || pkg?.peerDependencies?.[name]
-  if (!spec) return ''
-  return extractSemver(spec) || spec
+  return ''
 }
 
 /**

--- a/packages/core/src/utils/system/update.ts
+++ b/packages/core/src/utils/system/update.ts
@@ -225,18 +225,22 @@ export const checkPkgUpdate = async (
 export const getPkgVersion = async (name: string): Promise<string> => {
   /**
    * 获取指定包的本地版本号：
-   * 1) 优先从 `npm list` 输出中解析完整语义化版本
-   * 2) 若未安装或解析失败，兜底从 package.json 中提取语义化版本
+   * 1) 若查询的就是当前项目自身，直接读取 package.json 的 version
+   * 2) 优先从 `npm list` 输出中解析完整语义化版本
+   * 3) 若未安装或解析失败，兜底从 package.json 的依赖约束中提取语义化版本
    */
+  const pkg = await getPkg()
+  // 如果查询的就是当前项目自身，直接返回版本号
+  // npm list 不会将项目自身视为已安装的依赖，会返回 (empty)，因此必须提前处理
+  if (pkg?.name === name) {
+    return pkg.version || ''
+  }
+
   const { stdout, error } = await exec(`npm list ${name} --depth=0`)
   if (stdout) {
     const data = stdout.toString()
-    // node-karin@1.4.1 D:\\Github\\Karin-dev\\packages\\core\n└── @karinjs/plugin-basic@ extraneous
-    if (data.includes('empty') || data.includes('extraneous')) {
-      throw new Error(`获取失败，${name} 未安装`)
-    }
-
     // 精确从 npm list 中抓取 <name>@<version>，version 支持完整语义化格式
+    // extraneous/empty 仅代表 npm 依赖树中的状态，只要输出中有版本号就应提取
     const esc = escapeRegex(name)
     const reg = new RegExp(`${esc}@([0-9A-Za-z-.+]+)`, 'gm')
     const match = reg.exec(data)
@@ -247,14 +251,13 @@ export const getPkgVersion = async (name: string): Promise<string> => {
 
   if (error) {
     const stack = error?.stack?.toString() || ''
-    if (stack.includes('empty') || stack.includes('extraneous')) {
+    if (stack.includes('empty')) {
       throw new Error(`获取失败，${name} 未安装`)
     }
     throw error
   }
 
   /** 兜底：使用 package.json 中的版本约束，提取语义化版本 */
-  const pkg = await getPkg()
   const spec = pkg?.dependencies?.[name] || pkg?.devDependencies?.[name] || pkg?.peerDependencies?.[name]
   if (!spec) return ''
   return extractSemver(spec) || spec


### PR DESCRIPTION
## Summary by Sourcery

改进 `getPkgVersion` 中本地包版本解析逻辑，以正确处理当前项目，并避免将已安装的插件误判为缺失。

错误修复（Bug Fixes）：
- 将当前项目的包名作为特殊情况处理，不再依赖会忽略当前项目本身的 `npm list`，而是直接从 `package.json` 中读取其版本。
- 不再将 `npm list` 输出中的多余（extraneous）条目视为未安装的包，仅在 `npm` 报告空依赖树时才抛出“未安装”错误，从而减少在检查插件安装状态时的误报。

增强功能（Enhancements）：
- 当 `npm list` 解析失败时，版本解析的回退逻辑现在会始终使用 `package.json` 中的依赖约束来解析版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve local package version resolution in getPkgVersion to correctly handle the current project and avoid misclassifying installed plugins as missing.

Bug Fixes:
- Treat the current project package name as a special case by reading its version directly from package.json instead of relying on npm list, which omits the project itself.
- Stop treating extraneous npm list entries as uninstalled packages and only throw a not-installed error when npm reports an empty tree, reducing false negatives when checking plugin installation status.

Enhancements:
- Fallback version resolution now consistently uses dependency constraints from package.json when npm list parsing fails.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package version detection to better handle self-referencing projects, relaxed parsing of package manager output, and a more reliable manifest-based fallback for missing versions.
  * Resolved YAML module compatibility issues used by tooling, improving reliability of CLI/build/init/environment workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->