### PR TITLE
chore: 提升最低 Node 到 22，兼容 pnpm 9/10/11，引入 vitest 单元测试

### DIFF
--- a/.github/workflows/beta-version.yml
+++ b/.github/workflows/beta-version.yml
@@ -23,17 +23,16 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
           repository: ${{ github.event.pull_request.head.repo.full_name || '' }}
 
-      - name: 安装pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-          run_install: true
-
       - name: 安装Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
+
+      - name: 安装pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: true
 
       - name: 获取当前提交哈希
         run: |

--- a/.github/workflows/beta-version.yml
+++ b/.github/workflows/beta-version.yml
@@ -24,10 +24,16 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || '' }}
 
       - name: 安装pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
           run_install: true
+
+      - name: 安装Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
 
       - name: 获取当前提交哈希
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (node ${{ matrix.node }}, pnpm ${{ matrix.pnpm }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['22', '24', '26']
+        pnpm: ['10', '11']
+        exclude:
+          # node 26 is only paired with the newest pnpm to keep the matrix small
+          - node: '26'
+            pnpm: '10'
+    steps:
+      - name: 拉取代码
+        uses: actions/checkout@v4
+
+      - name: 安装pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ matrix.pnpm }}
+
+      - name: 安装Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+
+      - name: 安装依赖
+        run: pnpm install --frozen-lockfile=false
+
+      - name: 单元测试
+        run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,16 @@ jobs:
       fail-fast: false
       matrix:
         node: ['22', '24', '25', '26']
-        pnpm: ['10', '11']
+        pnpm: ['9', '10', '11']
         exclude:
-          # Trim matrix: only pair non-LTS Node versions with the newest pnpm.
+          # 矩阵裁剪：非 LTS Node 只配最新 pnpm，控制总作业数。
+          # pnpm 9 作为 baseline 跟 Node 22 / 24 配对足够。
+          - node: '25'
+            pnpm: '9'
           - node: '25'
             pnpm: '10'
+          - node: '26'
+            pnpm: '9'
           - node: '26'
             pnpm: '10'
     steps:
@@ -42,7 +47,8 @@ jobs:
           cache: pnpm
 
       - name: 安装依赖
-        run: pnpm install --frozen-lockfile=false
+        # 矩阵跨 pnpm 9/10/11，锁文件需要可重写
+        run: pnpm install --no-frozen-lockfile
 
       - name: 单元测试
         run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,10 @@ jobs:
           cache: pnpm
 
       - name: 安装依赖
-        # 矩阵跨 pnpm 9/10/11，锁文件需要可重写
-        run: pnpm install --no-frozen-lockfile
+        # 矩阵跨 pnpm 9/10/11，锁文件需要可重写。
+        # --ignore-scripts: pnpm 11 默认对未批准的构建脚本报 ERR_PNPM_IGNORED_BUILDS，
+        # 单测路径用不到 native 模块（sqlite3/node-pty 之类），直接跳过 postinstall。
+        run: pnpm install --no-frozen-lockfile --ignore-scripts
 
       - name: 单元测试
         run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['22', '24', '26']
+        node: ['22', '24', '25', '26']
         pnpm: ['10', '11']
         exclude:
-          # node 26 is only paired with the newest pnpm to keep the matrix small
+          # Trim matrix: only pair non-LTS Node versions with the newest pnpm.
+          - node: '25'
+            pnpm: '10'
           - node: '26'
             pnpm: '10'
     steps:
@@ -44,3 +46,12 @@ jobs:
 
       - name: 单元测试
         run: pnpm test
+
+      - name: 构建 create-karin
+        run: pnpm --filter create-karin run build
+
+      - name: create-karin 烟测 (--help)
+        # 验证打包后的 dist/index.mjs 在当前 Node 版本下能加载所有依赖
+        # (ora / prompts / kolorist / strip-json-comments) 并正常退出。
+        # 用于在合并前挡住 import 级别的 Node 兼容性回归。
+        run: node packages/create-karin/dist/index.mjs --help

--- a/.github/workflows/manual-publish-core.yml
+++ b/.github/workflows/manual-publish-core.yml
@@ -20,18 +20,18 @@ jobs:
       - name: 检出代码
         uses: actions/checkout@v4
 
-      # 安装pnpm
-      - name: 配置pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-          run_install: true
-
+      # 先装 Node，让 pnpm/action-setup 的 run_install 跑在 Node 22 下
       - name: 安装Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
+
+      # 安装pnpm
+      - name: 配置pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: true
 
       # 构建项目
       - name: 构建项目

--- a/.github/workflows/manual-publish-core.yml
+++ b/.github/workflows/manual-publish-core.yml
@@ -22,10 +22,16 @@ jobs:
 
       # 安装pnpm
       - name: 配置pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
           run_install: true
+
+      - name: 安装Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
 
       # 构建项目
       - name: 构建项目

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,15 +36,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
-          cache: pnpm
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - name: 安装依赖
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,14 +36,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
-
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 9
+          cache: pnpm
 
       - name: 安装依赖
         run: |

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "node": ">=22",
     "pnpm": ">=9"
   },
-  "packageManager": "pnpm@10.14.0",
   "devDependencies": {
     "@types/node": "^22.10.0",
     "@vitest/coverage-v8": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,13 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"
   },
+  "engines": {
+    "node": ">=22",
+    "pnpm": ">=9"
+  },
+  "packageManager": "pnpm@10.14.0",
   "devDependencies": {
-    "@types/node": "^18.19.84",
+    "@types/node": "^22.10.0",
     "@vitest/coverage-v8": "^3.1.3",
     "eslint": "^9.7.0",
     "eslint-plugin-prettier": "^5.2.5",

--- a/packages/cli-Internal/package.json
+++ b/packages/cli-Internal/package.json
@@ -33,7 +33,8 @@
     "commander": "^13.1.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22",
+    "pnpm": ">=9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,8 @@
     "pub": "npm publish --access public"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22",
+    "pnpm": ">=9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -192,7 +192,8 @@
     "dotenv": "npm:@karinjs/dotenv@^1.1.2"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22",
+    "pnpm": ">=9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/core/tests/utils/button/convert.test.ts
+++ b/packages/core/tests/utils/button/convert.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { karinToQQBot, qqbotToKarin } from '@/utils/button/convert'
+import type { ButtonElement, KeyboardElement } from '@/types/segment'
+
+const makeButton = (overrides: Partial<ButtonElement['data'][number]> = {}): ButtonElement => ({
+  type: 'button',
+  data: [
+    {
+      text: 'click me',
+      ...overrides,
+    },
+  ],
+})
+
+const makeKeyboard = (rows: KeyboardElement['rows']): KeyboardElement => ({
+  type: 'keyboard',
+  rows,
+})
+
+describe('utils/button/convert — karinToQQBot', () => {
+  it('returns one row containing one normal-type button when input is a single button', () => {
+    const result = karinToQQBot(makeButton())
+    expect(result).toHaveLength(1)
+    expect(result[0].buttons).toHaveLength(1)
+    const b = result[0].buttons[0]
+    expect(b.action.type).toBe(2) // default (no link, no callback)
+    expect(b.render_data.label).toBe('click me')
+    expect(b.action.permission.type).toBe(2)
+  })
+
+  it('detects link buttons (action.type 0)', () => {
+    const result = karinToQQBot(makeButton({ link: 'https://example.com' }))
+    expect(result[0].buttons[0].action.type).toBe(0)
+    expect(result[0].buttons[0].action.data).toBe('https://example.com')
+  })
+
+  it('detects callback buttons (action.type 1)', () => {
+    const result = karinToQQBot(makeButton({ callback: true, data: 'cb-payload' }))
+    expect(result[0].buttons[0].action.type).toBe(1)
+    expect(result[0].buttons[0].action.data).toBe('cb-payload')
+  })
+
+  it('flips permission.type to 1 for admin-only buttons', () => {
+    const result = karinToQQBot(makeButton({ admin: true }))
+    expect(result[0].buttons[0].action.permission.type).toBe(1)
+  })
+
+  it('forwards specify_user_ids when list is provided', () => {
+    const result = karinToQQBot(makeButton({ list: ['1', '2'] }))
+    const perm = result[0].buttons[0].action.permission
+    expect(perm.type).toBe(0)
+    expect(perm.specify_user_ids).toEqual(['1', '2'])
+  })
+
+  it('forwards specify_role_ids when role is provided', () => {
+    const result = karinToQQBot(makeButton({ role: ['r1'] }))
+    const perm = result[0].buttons[0].action.permission
+    expect(perm.type).toBe(3)
+    expect(perm.specify_role_ids).toEqual(['r1'])
+  })
+
+  it('assigns sequential ids across multi-row keyboards', () => {
+    const kb = makeKeyboard([
+      [{ text: 'a' }, { text: 'b' }],
+      [{ text: 'c' }],
+    ])
+    const result = karinToQQBot(kb)
+    expect(result).toHaveLength(2)
+    expect(result[0].buttons.map(b => b.id)).toEqual(['0', '1'])
+    expect(result[1].buttons.map(b => b.id)).toEqual(['2'])
+  })
+})
+
+describe('utils/button/convert — qqbotToKarin', () => {
+  it('emits a [button:link:...] string for link buttons', () => {
+    const qqRows = karinToQQBot(makeButton({ link: 'https://example.com' }))
+    const out = qqbotToKarin(qqRows)
+    expect(out).toContain('[button:')
+    expect(out).toContain('link:https://example.com')
+  })
+
+  it('emits callback:true for callback buttons', () => {
+    const qqRows = karinToQQBot(makeButton({ callback: true, data: 'cb' }))
+    const out = qqbotToKarin(qqRows)
+    expect(out).toContain('callback:true')
+  })
+
+  it('emits admin:true for admin permission buttons', () => {
+    const qqRows = karinToQQBot(makeButton({ admin: true }))
+    const out = qqbotToKarin(qqRows)
+    expect(out).toContain('admin:true')
+  })
+})

--- a/packages/core/tests/utils/common/number.test.ts
+++ b/packages/core/tests/utils/common/number.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest'
+import {
+  clamp,
+  random,
+  formatNumber,
+  percentage,
+  formatUnit,
+  isEven,
+  average,
+  round,
+  isNumber,
+  isNumberInArray,
+  createIdGenerator,
+} from '@/utils/common/number'
+
+describe('utils/common/number — clamp', () => {
+  it('returns value when inside range', () => {
+    expect(clamp(5, 0, 10)).toBe(5)
+  })
+  it('returns min when below range', () => {
+    expect(clamp(-1, 0, 10)).toBe(0)
+  })
+  it('returns max when above range', () => {
+    expect(clamp(11, 0, 10)).toBe(10)
+  })
+  it('handles negative ranges', () => {
+    expect(clamp(-5, -10, -1)).toBe(-5)
+    expect(clamp(-20, -10, -1)).toBe(-10)
+    expect(clamp(0, -10, -1)).toBe(-1)
+  })
+})
+
+describe('utils/common/number — random', () => {
+  it('returns integer within inclusive range', () => {
+    for (let i = 0; i < 200; i++) {
+      const r = random(1, 5)
+      expect(Number.isInteger(r)).toBe(true)
+      expect(r).toBeGreaterThanOrEqual(1)
+      expect(r).toBeLessThanOrEqual(5)
+    }
+  })
+  it('returns the only value when min === max', () => {
+    expect(random(7, 7)).toBe(7)
+  })
+})
+
+describe('utils/common/number — formatNumber', () => {
+  it('adds thousands separators with no decimals by default', () => {
+    expect(formatNumber(1234567)).toBe('1,234,567')
+  })
+  it('formats with the requested decimal precision', () => {
+    expect(formatNumber(1234.567, 2)).toBe('1,234.57')
+  })
+  it('handles zero and negatives', () => {
+    expect(formatNumber(0)).toBe('0')
+    expect(formatNumber(-1234)).toBe('-1,234')
+  })
+})
+
+describe('utils/common/number — percentage', () => {
+  it('returns 0 when total is 0 (no NaN)', () => {
+    expect(percentage(10, 0)).toBe(0)
+  })
+  it('computes basic percentages with 2 decimals by default', () => {
+    expect(percentage(75, 200)).toBe(37.5)
+  })
+  it('honours the digits argument', () => {
+    expect(percentage(1, 3, 4)).toBe(33.3333)
+  })
+})
+
+describe('utils/common/number — formatUnit', () => {
+  it('returns number string when under 1000', () => {
+    expect(formatUnit(500)).toBe('500')
+  })
+  it('formats thousands as K', () => {
+    expect(formatUnit(1234)).toBe('1.2K')
+  })
+  it('formats millions as M', () => {
+    expect(formatUnit(1234567)).toBe('1.2M')
+  })
+  it('formats billions as B', () => {
+    expect(formatUnit(1234567890)).toBe('1.2B')
+  })
+  it('respects digits parameter', () => {
+    expect(formatUnit(1500, 0)).toBe('2K')
+  })
+})
+
+describe('utils/common/number — isEven', () => {
+  it('detects even numbers', () => {
+    expect(isEven(0)).toBe(true)
+    expect(isEven(2)).toBe(true)
+    expect(isEven(-4)).toBe(true)
+  })
+  it('detects odd numbers', () => {
+    expect(isEven(1)).toBe(false)
+    expect(isEven(-3)).toBe(false)
+  })
+})
+
+describe('utils/common/number — average', () => {
+  it('returns 0 for empty arrays (no NaN)', () => {
+    expect(average([])).toBe(0)
+  })
+  it('computes the arithmetic mean', () => {
+    expect(average([1, 2, 3, 4, 5])).toBe(3)
+    expect(average([10, 20])).toBe(15)
+  })
+})
+
+describe('utils/common/number — round', () => {
+  it('rounds half up at integer level by default', () => {
+    expect(round(1.4)).toBe(1)
+    expect(round(1.5)).toBe(2)
+  })
+  it('rounds to the requested number of decimals', () => {
+    expect(round(1.234, 2)).toBe(1.23)
+    expect(round(1.235, 2)).toBe(1.24)
+  })
+})
+
+describe('utils/common/number — isNumber', () => {
+  it('returns the value when it is a number', () => {
+    expect(isNumber(42)).toBe(42)
+    expect(isNumber(0)).toBe(0)
+  })
+  it('returns the default when not a number', () => {
+    expect(isNumber('42')).toBe(0)
+    expect(isNumber(null)).toBe(0)
+    expect(isNumber(undefined, 7)).toBe(7)
+  })
+})
+
+describe('utils/common/number — isNumberInArray', () => {
+  it('returns the first numeric element', () => {
+    expect(isNumberInArray([1, '2', 3])).toBe(1)
+  })
+  it('returns the default when no number is present', () => {
+    expect(isNumberInArray(['1', '2', '3'], 0)).toBe(0)
+    expect(isNumberInArray([null, undefined, 'x'], 99)).toBe(99)
+  })
+})
+
+describe('utils/common/number — createIdGenerator', () => {
+  it('starts at 1 by default and increments', () => {
+    const next = createIdGenerator()
+    expect(next()).toBe(1)
+    expect(next()).toBe(2)
+    expect(next()).toBe(3)
+  })
+  it('starts after the given seed', () => {
+    const next = createIdGenerator(100)
+    expect(next()).toBe(101)
+    expect(next()).toBe(102)
+  })
+  it('keeps state per generator instance', () => {
+    const a = createIdGenerator()
+    const b = createIdGenerator()
+    a()
+    a()
+    expect(b()).toBe(1)
+    expect(a()).toBe(3)
+  })
+})

--- a/packages/core/tests/utils/common/sleep.test.ts
+++ b/packages/core/tests/utils/common/sleep.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { sleep } from '@/utils/common/sleep'
+
+describe('utils/common/sleep', () => {
+  it('resolves after at least the requested duration', async () => {
+    const start = Date.now()
+    await sleep(50)
+    const elapsed = Date.now() - start
+    // generous lower bound: timers can fire 5-10ms early on busy CI
+    expect(elapsed).toBeGreaterThanOrEqual(40)
+    expect(elapsed).toBeLessThan(500)
+  })
+
+  it('resolves immediately for 0 ms', async () => {
+    const start = Date.now()
+    await sleep(0)
+    expect(Date.now() - start).toBeLessThan(100)
+  })
+
+  it('returns a Promise', () => {
+    const p = sleep(0)
+    expect(p).toBeInstanceOf(Promise)
+    return p
+  })
+})

--- a/packages/core/tests/utils/common/string.test.ts
+++ b/packages/core/tests/utils/common/string.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { strToBool } from '@/utils/common/string'
+
+describe('utils/common/string — strToBool.array', () => {
+  it('coerces mixed values to non-empty strings', () => {
+    expect(strToBool.array([1, '2'])).toEqual(['1', '2'])
+  })
+  it('drops empty strings produced by String(null|undefined|NaN|"")', () => {
+    // String(null) === 'null', String(undefined) === 'undefined' -> length > 0; NaN -> 'NaN'
+    // Only literal empty string is dropped.
+    expect(strToBool.array(['3', ''])).toEqual(['3'])
+  })
+})
+
+describe('utils/common/string — strToBool.arrayExcludeNonString', () => {
+  it('keeps only non-empty string elements', () => {
+    expect(strToBool.arrayExcludeNonString(['1', '2', '3'])).toEqual(['1', '2', '3'])
+    expect(strToBool.arrayExcludeNonString(['1', '2', '3', null, undefined, NaN, ''])).toEqual([
+      '1',
+      '2',
+      '3',
+    ])
+  })
+})
+
+describe('utils/common/string — strToBool.string', () => {
+  it.each([
+    ['true', true],
+    ['1', true],
+    ['yes', true],
+    ['on', true],
+    ['false', false],
+    ['0', false],
+    ['no', false],
+    ['off', false],
+    ['', false],
+  ])('strToBool.string(%j) === %j', (input, expected) => {
+    expect(strToBool.string(input)).toBe(expected)
+  })
+})
+
+describe('utils/common/string — strToBool.number', () => {
+  it('parses numeric strings', () => {
+    expect(strToBool.number('1')).toBe(1)
+    expect(strToBool.number('2.5')).toBe(2.5)
+  })
+  it('returns NaN for non-numeric strings (current implementation)', () => {
+    // The implementation uses Number() which returns NaN for non-numeric; typeof NaN === 'number'
+    // so the default branch is never hit. This locks in current behavior.
+    expect(Number.isNaN(strToBool.number('abc'))).toBe(true)
+  })
+})
+
+describe('utils/common/string — strToBool.arrayNumber', () => {
+  it('converts a string array into numbers', () => {
+    expect(strToBool.arrayNumber(['1', '2', '3'])).toEqual([1, 2, 3])
+  })
+})
+
+describe('utils/common/string — strToBool.arrayString', () => {
+  it('returns the first nested array as a string array', () => {
+    expect(strToBool.arrayString([['1', 2, '3']])).toEqual(['1', '3'])
+  })
+  it('returns an empty array when no nested array is found', () => {
+    expect(strToBool.arrayString(['1', '2', '3'])).toEqual([])
+  })
+})
+
+describe('utils/common/string — strToBool.mergeArray', () => {
+  it('merges multiple arrays and removes duplicates', () => {
+    expect(strToBool.mergeArray<string>(['1', '2', '3'], ['3', '4'])).toEqual(['1', '2', '3', '4'])
+  })
+  it('ignores non-array arguments', () => {
+    expect(strToBool.mergeArray<number>([1, 2], 'not-array', [2, 3])).toEqual([1, 2, 3])
+  })
+})

--- a/packages/core/tests/utils/common/uptime.test.ts
+++ b/packages/core/tests/utils/common/uptime.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { uptime } from '@/utils/common/uptime'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('utils/common/uptime', () => {
+  it('formats just seconds when uptime is short', () => {
+    vi.spyOn(process, 'uptime').mockReturnValue(45)
+    expect(uptime()).toBe('45秒')
+  })
+
+  it('formats minutes and seconds', () => {
+    vi.spyOn(process, 'uptime').mockReturnValue(3 * 60 + 4)
+    expect(uptime()).toBe('3分钟4秒')
+  })
+
+  it('formats hours/minutes/seconds', () => {
+    vi.spyOn(process, 'uptime').mockReturnValue(2 * 3600 + 3 * 60 + 4)
+    expect(uptime()).toBe('2小时3分钟4秒')
+  })
+
+  it('omits seconds once day is non-zero', () => {
+    vi.spyOn(process, 'uptime').mockReturnValue(86400 + 7200 + 180 + 5)
+    expect(uptime()).toBe('1天2小时3分钟')
+  })
+
+  it('returns an empty string for zero uptime', () => {
+    vi.spyOn(process, 'uptime').mockReturnValue(0)
+    expect(uptime()).toBe('')
+  })
+})

--- a/packages/core/tests/utils/fs/json.test.ts
+++ b/packages/core/tests/utils/fs/json.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  readJsonSync,
+  writeJsonSync,
+  readJson,
+  writeJson,
+  json,
+} from '@/utils/fs/json'
+
+let tmpDir: string
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'karin-json-test-'))
+})
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('utils/fs/json — sync', () => {
+  it('writes and reads JSON', () => {
+    const file = path.join(tmpDir, 'sync.json')
+    expect(writeJsonSync(file, { a: 1, b: 'two' })).toBe(true)
+    expect(readJsonSync(file)).toEqual({ a: 1, b: 'two' })
+  })
+
+  it('returns null on missing file without throwing', () => {
+    expect(readJsonSync(path.join(tmpDir, 'missing.json'))).toBeNull()
+  })
+
+  it('throws on missing file when isThrow=true', () => {
+    expect(() => readJsonSync(path.join(tmpDir, 'missing.json'), true)).toThrow()
+  })
+
+  it('returns false on write failure (invalid target) without throwing', () => {
+    // A directory cannot be written to as a file
+    expect(writeJsonSync(tmpDir, { foo: 'bar' })).toBe(false)
+  })
+
+  it('throws on write failure when isThrow=true', () => {
+    expect(() => writeJsonSync(tmpDir, { foo: 'bar' }, true)).toThrow()
+  })
+})
+
+describe('utils/fs/json — async', () => {
+  it('writes and reads JSON', async () => {
+    const file = path.join(tmpDir, 'async.json')
+    expect(await writeJson(file, { x: [1, 2, 3] })).toBe(true)
+    await expect(readJson(file)).resolves.toEqual({ x: [1, 2, 3] })
+  })
+
+  it('returns null when missing without throwing', async () => {
+    await expect(readJson(path.join(tmpDir, 'missing-async.json'))).resolves.toBeNull()
+  })
+
+  it('throws when isThrow=true on missing file', async () => {
+    await expect(readJson(path.join(tmpDir, 'missing-async.json'), true)).rejects.toBeDefined()
+  })
+})
+
+describe('utils/fs/json — namespace export', () => {
+  it('exposes sync and async helpers', () => {
+    expect(json.readSync).toBe(readJsonSync)
+    expect(json.writeSync).toBe(writeJsonSync)
+    expect(json.read).toBe(readJson)
+    expect(json.write).toBe(writeJson)
+  })
+})

--- a/packages/core/tests/utils/fs/path.test.ts
+++ b/packages/core/tests/utils/fs/path.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import path from 'node:path'
+import {
+  splitPath,
+  getRelPath,
+  formatPath,
+  isPathEqual,
+  isSubPath,
+} from '@/utils/fs/path'
+
+describe('utils/fs/path — splitPath', () => {
+  it('returns the dirname and basename', () => {
+    const filePath = path.join('foo', 'bar', 'file.txt')
+    const { dirname, basename } = splitPath(filePath)
+    expect(basename).toBe('file.txt')
+    // dirname may have native separators stripped — just verify it doesn't include the basename
+    expect(dirname).not.toContain('file.txt')
+    expect(dirname.length).toBeGreaterThan(0)
+  })
+})
+
+describe('utils/fs/path — getRelPath', () => {
+  it('normalizes backslashes and strips ./ and trailing slashes', () => {
+    expect(getRelPath('./plugins/karin-plugin-example/index.ts')).toBe(
+      'plugins/karin-plugin-example/index.ts',
+    )
+    expect(getRelPath('.\\plugins\\karin-plugin-example\\index.ts')).toBe(
+      'plugins/karin-plugin-example/index.ts',
+    )
+    expect(getRelPath('foo/bar/')).toBe('foo/bar')
+  })
+})
+
+describe('utils/fs/path — formatPath', () => {
+  it('returns an absolute path with forward slashes', () => {
+    const result = formatPath('./foo/bar')
+    expect(path.isAbsolute(result)).toBe(true)
+    expect(result).not.toContain('\\')
+  })
+})
+
+describe('utils/fs/path — isPathEqual', () => {
+  it('returns true for identical strings', () => {
+    expect(isPathEqual('foo/bar', 'foo/bar')).toBe(true)
+  })
+
+  it('compares paths after normalization', () => {
+    expect(isPathEqual('./foo/bar', 'foo/bar')).toBe(true)
+  })
+
+  it('is case-insensitive on Windows, case-sensitive elsewhere', () => {
+    const result = isPathEqual('FOO/BAR', 'foo/bar')
+    if (process.platform === 'win32') {
+      expect(result).toBe(true)
+    } else {
+      expect(result).toBe(false)
+    }
+  })
+})
+
+describe('utils/fs/path — isSubPath', () => {
+  it('returns truthy for paths under the root', () => {
+    expect(isSubPath(process.cwd(), path.join(process.cwd(), 'a', 'b'))).toBeTruthy()
+  })
+
+  it('returns falsy for paths outside the root', () => {
+    expect(isSubPath(path.join(process.cwd(), 'a'), path.join(process.cwd(), 'b'))).toBeFalsy()
+  })
+
+  it('returns falsy when target equals root (relative is empty)', () => {
+    expect(isSubPath(process.cwd(), process.cwd())).toBeFalsy()
+  })
+})

--- a/packages/core/tests/utils/ini/index.test.ts
+++ b/packages/core/tests/utils/ini/index.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { ini, createINIParser } from '@/utils/ini/index'
+
+let tmpDir: string
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'karin-ini-test-'))
+})
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('utils/ini — read', () => {
+  it('returns an empty object when the file does not exist', () => {
+    const missing = path.join(tmpDir, 'no-such-file.ini')
+    expect(ini.read(missing)).toEqual({})
+  })
+
+  it('parses key=value pairs and ignores comments and blanks', () => {
+    const file = path.join(tmpDir, 'sample.ini')
+    fs.writeFileSync(
+      file,
+      [
+        '# comment',
+        '; another comment',
+        '',
+        'registry=https://registry.npmjs.org/',
+        '  store-dir = /opt/store  ',
+        'empty-value=',
+        'bad-line-without-equals',
+      ].join('\n'),
+    )
+    const parsed = ini.read(file)
+    expect(parsed.registry).toBe('https://registry.npmjs.org/')
+    expect(parsed['store-dir']).toBe('/opt/store')
+    expect(parsed['empty-value']).toBe('')
+    expect(parsed).not.toHaveProperty('bad-line-without-equals')
+  })
+})
+
+describe('utils/ini — write', () => {
+  it('writes and round-trips key=value content', () => {
+    const file = path.join(tmpDir, 'out.ini')
+    const data = { foo: 'bar', baz: '1' }
+    expect(ini.write(data, file)).toBe(true)
+    expect(ini.read(file)).toEqual(data)
+  })
+
+  it('creates intermediate directories', () => {
+    const file = path.join(tmpDir, 'nested', 'deep', 'file.ini')
+    expect(ini.write({ a: 'b' }, file)).toBe(true)
+    expect(fs.existsSync(file)).toBe(true)
+    expect(ini.read(file)).toEqual({ a: 'b' })
+  })
+})
+
+describe('utils/ini — createINIParser', () => {
+  it('factory produces a parser with read/write', () => {
+    const parser = createINIParser()
+    expect(typeof parser.read).toBe('function')
+    expect(typeof parser.write).toBe('function')
+  })
+})

--- a/packages/core/tests/utils/system/range.test.ts
+++ b/packages/core/tests/utils/system/range.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { satisfies } from '@/utils/system/range'
+
+describe('utils/system/range — satisfies (basic operators)', () => {
+  it('matches caret upper bounds', () => {
+    expect(satisfies('^1.0.0', '1.0.1')).toBe(true)
+    expect(satisfies('^1.0.0', '1.9.9')).toBe(true)
+    expect(satisfies('^1.0.0', '2.0.0')).toBe(false)
+    expect(satisfies('^1.0.0', '0.0.1')).toBe(false)
+  })
+
+  it('handles 0.x caret semantics (^0.y.z → >=0.y.z <0.(y+1).0)', () => {
+    expect(satisfies('^0.1.0', '0.1.5')).toBe(true)
+    expect(satisfies('^0.1.0', '0.2.0')).toBe(false)
+  })
+
+  it('respects gte/lte/gt/lt', () => {
+    expect(satisfies('>=1.0.0', '1.0.0')).toBe(true)
+    expect(satisfies('>=1.0.0', '0.0.1')).toBe(false)
+    expect(satisfies('<=1.0.0', '1.0.0')).toBe(true)
+    expect(satisfies('<=1.0.0', '2.0.0')).toBe(false)
+    expect(satisfies('>1.0.0', '1.0.1')).toBe(true)
+    expect(satisfies('>1.0.0', '1.0.0')).toBe(false)
+    expect(satisfies('<1.0.0', '0.9.9')).toBe(true)
+    expect(satisfies('<1.0.0', '1.0.0')).toBe(false)
+  })
+
+  it('composes whitespace-separated conditions with AND semantics', () => {
+    expect(satisfies('>=1.0.0 <2.0.0', '1.0.0')).toBe(true)
+    expect(satisfies('>=1.0.0 <2.0.0', '2.0.0')).toBe(false)
+  })
+})
+
+describe('utils/system/range — satisfies (prereleases)', () => {
+  it('treats no-prerelease as greater than prerelease', () => {
+    expect(satisfies('1.0.0-alpha', '1.0.0-beta')).toBe(false)
+    expect(satisfies('1.0.0-beta', '1.0.0-alpha')).toBe(false)
+  })
+
+  it('orders alpha < beta < rc', () => {
+    expect(satisfies('^1.0.0-alpha', '1.0.0-beta')).toBe(true)
+    expect(satisfies('^1.0.0-beta', '1.0.0-alpha')).toBe(false)
+  })
+
+  it('matches identical prerelease', () => {
+    expect(satisfies('^1.0.0-beta', '1.0.0-beta')).toBe(true)
+    expect(satisfies('^1.0.0-alpha', '1.0.0-alpha')).toBe(true)
+  })
+
+  it('refuses prerelease-vs-release mix when the range demands prerelease', () => {
+    expect(satisfies('>=1.0.0-beta', '1.0.0-alpha')).toBe(false)
+  })
+})
+
+describe('utils/system/range — satisfies (wildcards)', () => {
+  it('matches patch wildcards', () => {
+    expect(satisfies('1.0.x', '1.0.1')).toBe(true)
+    expect(satisfies('1.0.x', '1.1.0')).toBe(false)
+  })
+  it('matches minor wildcards', () => {
+    expect(satisfies('1.x.x', '1.2.3')).toBe(true)
+  })
+  it('matches single-position wildcards even at minor', () => {
+    expect(satisfies('1.x.0', '1.2.0')).toBe(true)
+    expect(satisfies('1.x.0', '1.2.1')).toBe(false)
+  })
+})

--- a/packages/core/tests/utils/system/time.test.ts
+++ b/packages/core/tests/utils/system/time.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { uptime, formatTime } from '@/utils/system/time'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('utils/system/time — uptime', () => {
+  it('formats just seconds when short', () => {
+    vi.spyOn(process, 'uptime').mockReturnValue(45)
+    expect(uptime()).toBe('45秒')
+  })
+
+  it('formats hours/minutes/seconds', () => {
+    vi.spyOn(process, 'uptime').mockReturnValue(2 * 3600 + 3 * 60 + 4)
+    expect(uptime()).toBe('2小时3分钟4秒')
+  })
+
+  it('omits seconds when day is non-zero', () => {
+    vi.spyOn(process, 'uptime').mockReturnValue(86400 + 7200 + 180 + 5)
+    expect(uptime()).toBe('1天2小时3分钟')
+  })
+})
+
+describe('utils/system/time — formatTime', () => {
+  it('returns the elapsed gap between two ms timestamps', () => {
+    // 1 hour 2 minutes 3 seconds apart
+    const t1 = 1_700_000_000_000
+    const t2 = t1 + (1 * 3600 + 2 * 60 + 3) * 1000
+    expect(formatTime(t1, t2)).toBe('1小时2分钟3秒')
+  })
+
+  // The implementation's regex /0[天时分秒]/ never matches the '小' in '小时',
+  // so a zero hour stays as the (misspelt) '0小时'. Lock in the current behavior
+  // rather than asserting an idealized result.
+  it('drops zero day/min/sec but keeps a quirky "0小时钟" segment for zero hour', () => {
+    const t1 = 1_700_000_000_000
+    const t2 = t1 + 5_000 // 5 seconds
+    expect(formatTime(t1, t2)).toBe('0小时钟5秒')
+  })
+
+  it('defaults to now() for the second argument', () => {
+    const now = 1_800_000_000_000
+    vi.spyOn(Date, 'now').mockReturnValue(now)
+    const t1 = now - 65_000 // 1 minute 5 seconds ago
+    expect(formatTime(t1)).toBe('0小时1分钟5秒')
+  })
+
+  it('accepts 13-digit ms timestamps and returns a non-empty formatted string', () => {
+    const t2 = 1_700_000_000_000
+    const t1 = t2 - 3_600_000 // 1 hour earlier
+    const result = formatTime(t1, t2)
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
+    expect(result).toContain('1小时')
+  })
+})

--- a/packages/create-karin/package.json
+++ b/packages/create-karin/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@karinjs/axios": "^1.1.8",
-    "@types/node": "^20.11.0",
+    "@types/node": "^22.10.0",
     "@types/prompts": "^2.4.9",
     "@types/strip-json-comments": "^3.0.0",
     "ora": "^8.2.0",
@@ -43,7 +43,8 @@
     "typescript": "^5.3.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22",
+    "pnpm": ">=9"
   },
   "publishConfig": {
     "access": "public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,11 +13,11 @@ importers:
         version: link:packages/core
     devDependencies:
       '@types/node':
-        specifier: ^18.19.84
-        version: 18.19.84
+        specifier: ^22.10.0
+        version: 22.10.7
       '@vitest/coverage-v8':
         specifier: ^3.1.3
-        version: 3.1.3(vitest@3.1.3(@types/debug@4.1.12)(@types/node@18.19.84)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))
+        version: 3.1.3(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))
       eslint:
         specifier: ^9.7.0
         version: 9.21.0(jiti@1.21.7)
@@ -41,7 +41,7 @@ importers:
         version: 5.39.0
       tsup:
         specifier: ^8.4.0
-        version: 8.4.0(@microsoft/api-extractor@7.52.3(@types/node@18.19.84))(@swc/core@1.11.13(@swc/helpers@0.5.15))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.8.1)
+        version: 8.4.0(@microsoft/api-extractor@7.52.3(@types/node@22.10.7))(@swc/core@1.11.13(@swc/helpers@0.5.15))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.8.1)
       tsx:
         specifier: ^4.19.3
         version: 4.19.3
@@ -59,13 +59,13 @@ importers:
         version: 5.8.2
       vite:
         specifier: ^6.3.6
-        version: 6.3.6(@types/node@18.19.84)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
+        version: 6.3.6(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@18.19.84)(rollup@4.50.1)(typescript@5.8.2)(vite@6.3.6(@types/node@18.19.84)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))
+        version: 4.5.4(@types/node@22.10.7)(rollup@4.50.1)(typescript@5.8.2)(vite@6.3.6(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))
       vitest:
         specifier: ^3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@18.19.84)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
 
   packages/cli: {}
 
@@ -165,8 +165,8 @@ importers:
         specifier: ^1.1.8
         version: 1.1.8
       '@types/node':
-        specifier: ^20.11.0
-        version: 20.17.28
+        specifier: ^22.10.0
+        version: 22.10.7
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
@@ -181,7 +181,7 @@ importers:
         version: 5.0.1
       tsup:
         specifier: ^8.0.1
-        version: 8.4.0(@microsoft/api-extractor@7.52.3(@types/node@20.17.28))(@swc/core@1.11.13(@swc/helpers@0.5.15))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.8.1)
+        version: 8.4.0(@microsoft/api-extractor@7.52.3(@types/node@22.10.7))(@swc/core@1.11.13(@swc/helpers@0.5.15))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.3.3
         version: 5.8.2
@@ -517,7 +517,7 @@ importers:
         version: 3.8.1(@swc/helpers@0.5.15)(vite@6.3.6(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))
       autoprefixer:
         specifier: 10.4.20
-        version: 10.4.20(postcss@8.5.6)
+        version: 10.4.20(postcss@8.5.3)
       react-scan:
         specifier: ^0.3.3
         version: 0.3.3(@types/react@19.0.7)(react-dom@19.1.0(react@19.1.0))(react-router-dom@7.4.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-router@7.4.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(rollup@4.50.1)
@@ -3625,9 +3625,6 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@18.19.84':
-    resolution: {integrity: sha512-ACYy2HGcZPHxEeWTqowTF7dhXN+JU1o7Gr4b41klnn6pj2LD6rsiGqSZojMdk1Jh2ys3m76ap+ae1vvE4+5+vg==}
-
   '@types/node@20.17.28':
     resolution: {integrity: sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==}
 
@@ -6523,9 +6520,6 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
@@ -8671,22 +8665,13 @@ snapshots:
 
   '@karinjs/ws@1.0.4': {}
 
-  '@microsoft/api-extractor-model@7.30.5(@types/node@18.19.84)':
+  '@microsoft/api-extractor-model@7.30.5(@types/node@22.10.7)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.13.0(@types/node@18.19.84)
+      '@rushstack/node-core-library': 5.13.0(@types/node@22.10.7)
     transitivePeerDependencies:
       - '@types/node'
-
-  '@microsoft/api-extractor-model@7.30.5(@types/node@20.17.28)':
-    dependencies:
-      '@microsoft/tsdoc': 0.15.1
-      '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.13.0(@types/node@20.17.28)
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   '@microsoft/api-extractor-model@7.30.5(@types/node@24.0.3)':
     dependencies:
@@ -8697,15 +8682,15 @@ snapshots:
       - '@types/node'
     optional: true
 
-  '@microsoft/api-extractor@7.52.3(@types/node@18.19.84)':
+  '@microsoft/api-extractor@7.52.3(@types/node@22.10.7)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.30.5(@types/node@18.19.84)
+      '@microsoft/api-extractor-model': 7.30.5(@types/node@22.10.7)
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.13.0(@types/node@18.19.84)
+      '@rushstack/node-core-library': 5.13.0(@types/node@22.10.7)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.15.2(@types/node@18.19.84)
-      '@rushstack/ts-command-line': 4.23.7(@types/node@18.19.84)
+      '@rushstack/terminal': 0.15.2(@types/node@22.10.7)
+      '@rushstack/ts-command-line': 4.23.7(@types/node@22.10.7)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.10
@@ -8714,25 +8699,6 @@ snapshots:
       typescript: 5.8.2
     transitivePeerDependencies:
       - '@types/node'
-
-  '@microsoft/api-extractor@7.52.3(@types/node@20.17.28)':
-    dependencies:
-      '@microsoft/api-extractor-model': 7.30.5(@types/node@20.17.28)
-      '@microsoft/tsdoc': 0.15.1
-      '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.13.0(@types/node@20.17.28)
-      '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.15.2(@types/node@20.17.28)
-      '@rushstack/ts-command-line': 4.23.7(@types/node@20.17.28)
-      lodash: 4.17.21
-      minimatch: 3.0.8
-      resolve: 1.22.10
-      semver: 7.5.4
-      source-map: 0.6.1
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   '@microsoft/api-extractor@7.52.3(@types/node@24.0.3)':
     dependencies:
@@ -10291,7 +10257,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.50.1':
     optional: true
 
-  '@rushstack/node-core-library@5.13.0(@types/node@18.19.84)':
+  '@rushstack/node-core-library@5.13.0(@types/node@22.10.7)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -10302,21 +10268,7 @@ snapshots:
       resolve: 1.22.10
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 18.19.84
-
-  '@rushstack/node-core-library@5.13.0(@types/node@20.17.28)':
-    dependencies:
-      ajv: 8.13.0
-      ajv-draft-04: 1.0.0(ajv@8.13.0)
-      ajv-formats: 3.0.1(ajv@8.13.0)
-      fs-extra: 11.3.1
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.10
-      semver: 7.5.4
-    optionalDependencies:
-      '@types/node': 20.17.28
-    optional: true
+      '@types/node': 22.10.7
 
   '@rushstack/node-core-library@5.13.0(@types/node@24.0.3)':
     dependencies:
@@ -10337,20 +10289,12 @@ snapshots:
       resolve: 1.22.10
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.15.2(@types/node@18.19.84)':
+  '@rushstack/terminal@0.15.2(@types/node@22.10.7)':
     dependencies:
-      '@rushstack/node-core-library': 5.13.0(@types/node@18.19.84)
+      '@rushstack/node-core-library': 5.13.0(@types/node@22.10.7)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 18.19.84
-
-  '@rushstack/terminal@0.15.2(@types/node@20.17.28)':
-    dependencies:
-      '@rushstack/node-core-library': 5.13.0(@types/node@20.17.28)
-      supports-color: 8.1.1
-    optionalDependencies:
-      '@types/node': 20.17.28
-    optional: true
+      '@types/node': 22.10.7
 
   '@rushstack/terminal@0.15.2(@types/node@24.0.3)':
     dependencies:
@@ -10360,24 +10304,14 @@ snapshots:
       '@types/node': 24.0.3
     optional: true
 
-  '@rushstack/ts-command-line@4.23.7(@types/node@18.19.84)':
+  '@rushstack/ts-command-line@4.23.7(@types/node@22.10.7)':
     dependencies:
-      '@rushstack/terminal': 0.15.2(@types/node@18.19.84)
+      '@rushstack/terminal': 0.15.2(@types/node@22.10.7)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
-
-  '@rushstack/ts-command-line@4.23.7(@types/node@20.17.28)':
-    dependencies:
-      '@rushstack/terminal': 0.15.2(@types/node@20.17.28)
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      string-argv: 0.3.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   '@rushstack/ts-command-line@4.23.7(@types/node@24.0.3)':
     dependencies:
@@ -10526,11 +10460,11 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 24.0.3
+      '@types/node': 22.10.7
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 24.0.3
+      '@types/node': 22.10.7
 
   '@types/cookie@0.6.0': {}
 
@@ -10552,7 +10486,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.0.6':
     dependencies:
-      '@types/node': 24.0.3
+      '@types/node': 22.10.7
       '@types/qs': 6.9.18
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -10574,7 +10508,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 24.0.3
+      '@types/node': 22.10.7
 
   '@types/lodash.isequal@4.5.8':
     dependencies:
@@ -10590,10 +10524,6 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@18.19.84':
-    dependencies:
-      undici-types: 5.26.5
-
   '@types/node@20.17.28':
     dependencies:
       undici-types: 6.19.8
@@ -10608,7 +10538,7 @@ snapshots:
 
   '@types/prompts@2.4.9':
     dependencies:
-      '@types/node': 20.17.28
+      '@types/node': 22.10.7
       kleur: 3.0.3
 
   '@types/qs@6.9.18': {}
@@ -10639,12 +10569,12 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 24.0.3
+      '@types/node': 22.10.7
 
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 24.0.3
+      '@types/node': 22.10.7
       '@types/send': 0.17.4
 
   '@types/stats.js@0.17.3': {}
@@ -10674,7 +10604,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 24.0.3
+      '@types/node': 22.10.7
 
   '@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.21.0(jiti@1.21.7))(typescript@5.8.2))(eslint@9.21.0(jiti@1.21.7))(typescript@5.8.2)':
     dependencies:
@@ -10860,7 +10790,7 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitest/coverage-v8@3.1.3(vitest@3.1.3(@types/debug@4.1.12)(@types/node@18.19.84)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))':
+  '@vitest/coverage-v8@3.1.3(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -10874,7 +10804,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@18.19.84)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
+      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -10885,13 +10815,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.3(vite@6.3.6(@types/node@18.19.84)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))':
+  '@vitest/mocker@3.1.3(vite@6.3.6(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.6(@types/node@18.19.84)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
+      vite: 6.3.6(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.1.3':
     dependencies:
@@ -11121,14 +11051,14 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  autoprefixer@10.4.20(postcss@8.5.6):
+  autoprefixer@10.4.20(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
       caniuse-lite: 1.0.30001707
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -14133,7 +14063,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.4.0(@microsoft/api-extractor@7.52.3(@types/node@18.19.84))(@swc/core@1.11.13(@swc/helpers@0.5.15))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.8.1):
+  tsup@8.4.0(@microsoft/api-extractor@7.52.3(@types/node@22.10.7))(@swc/core@1.11.13(@swc/helpers@0.5.15))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.8.1):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.1)
       cac: 6.7.14
@@ -14152,36 +14082,7 @@ snapshots:
       tinyglobby: 0.2.12
       tree-kill: 1.2.2
     optionalDependencies:
-      '@microsoft/api-extractor': 7.52.3(@types/node@18.19.84)
-      '@swc/core': 1.11.13(@swc/helpers@0.5.15)
-      postcss: 8.5.6
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
-  tsup@8.4.0(@microsoft/api-extractor@7.52.3(@types/node@20.17.28))(@swc/core@1.11.13(@swc/helpers@0.5.15))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.8.1):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.1)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.0
-      esbuild: 0.25.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.19.3)(yaml@2.8.1)
-      resolve-from: 5.0.0
-      rollup: 4.38.0
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.12
-      tree-kill: 1.2.2
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.52.3(@types/node@20.17.28)
+      '@microsoft/api-extractor': 7.52.3(@types/node@22.10.7)
       '@swc/core': 1.11.13(@swc/helpers@0.5.15)
       postcss: 8.5.6
       typescript: 5.8.2
@@ -14319,8 +14220,6 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@5.26.5: {}
-
   undici-types@6.19.8: {}
 
   undici-types@6.20.0: {}
@@ -14436,13 +14335,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.1.3(@types/node@18.19.84)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1):
+  vite-node@3.1.3(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.6(@types/node@18.19.84)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
+      vite: 6.3.6(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -14466,9 +14365,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-dts@4.5.4(@types/node@18.19.84)(rollup@4.50.1)(typescript@5.8.2)(vite@6.3.6(@types/node@18.19.84)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)):
+  vite-plugin-dts@4.5.4(@types/node@22.10.7)(rollup@4.50.1)(typescript@5.8.2)(vite@6.3.6(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)):
     dependencies:
-      '@microsoft/api-extractor': 7.52.3(@types/node@18.19.84)
+      '@microsoft/api-extractor': 7.52.3(@types/node@22.10.7)
       '@rollup/pluginutils': 5.1.4(rollup@4.50.1)
       '@volar/typescript': 2.4.12
       '@vue/language-core': 2.2.0(typescript@5.8.2)
@@ -14479,7 +14378,7 @@ snapshots:
       magic-string: 0.30.17
       typescript: 5.8.2
     optionalDependencies:
-      vite: 6.3.6(@types/node@18.19.84)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
+      vite: 6.3.6(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
@@ -14510,23 +14409,6 @@ snapshots:
       - supports-color
       - typescript
 
-  vite@6.3.6(@types/node@18.19.84)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1):
-    dependencies:
-      esbuild: 0.25.9
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.50.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 18.19.84
-      fsevents: 2.3.3
-      jiti: 1.21.7
-      sass: 1.86.0
-      terser: 5.39.0
-      tsx: 4.19.3
-      yaml: 2.8.1
-
   vite@6.3.6(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.9
@@ -14544,10 +14426,10 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.8.1
 
-  vitest@3.1.3(@types/debug@4.1.12)(@types/node@18.19.84)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1):
+  vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 3.1.3
-      '@vitest/mocker': 3.1.3(vite@6.3.6(@types/node@18.19.84)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))
+      '@vitest/mocker': 3.1.3(vite@6.3.6(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))
       '@vitest/pretty-format': 3.1.3
       '@vitest/runner': 3.1.3
       '@vitest/snapshot': 3.1.3
@@ -14564,12 +14446,12 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.6(@types/node@18.19.84)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
-      vite-node: 3.1.3(@types/node@18.19.84)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
+      vite: 6.3.6(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
+      vite-node: 3.1.3(@types/node@22.10.7)(jiti@1.21.7)(sass@1.86.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 18.19.84
+      '@types/node': 22.10.7
     transitivePeerDependencies:
       - jiti
       - less

--- a/tests/check-pnpm-version.sh
+++ b/tests/check-pnpm-version.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -u
+cd /tmp
+echo "Outside project, pnpm 11 binary:"
+~/node-versions/_pnpm-cache/22/node_modules/.bin/pnpm --version
+echo
+echo "Inside project (with packageManager pin), pnpm 11 binary:"
+cd /mnt/d/Github/Karin-test-build
+~/node-versions/_pnpm-cache/22/node_modules/.bin/pnpm --version

--- a/tests/run-matrix.sh
+++ b/tests/run-matrix.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Runs the vitest suite across Node 22/24/26 and pnpm 10/11 inside WSL.
+# Used to verify the engine bump. Not invoked by CI.
+set -uo pipefail
+
+declare -A NODE_PATHS=(
+  ["22"]="$(which node)"
+  ["24"]="$HOME/node-versions/v24.15.0/bin/node"
+  ["26"]="$HOME/node-versions/v26.1.0/bin/node"
+)
+
+declare -A NODE_DIRS=(
+  ["22"]="$(dirname "$(which node)")"
+  ["24"]="$HOME/node-versions/v24.15.0/bin"
+  ["26"]="$HOME/node-versions/v26.1.0/bin"
+)
+
+PNPM_VERSIONS=("10.14.0" "11.1.1")
+
+REPORT="/tmp/karin-matrix-report.txt"
+: > "$REPORT"
+
+for NV in 22 24 26; do
+  for PV in "${PNPM_VERSIONS[@]}"; do
+    NODE_BIN="${NODE_DIRS[$NV]}"
+    if [ ! -x "$NODE_BIN/node" ]; then
+      echo "SKIP node $NV (no binary at $NODE_BIN/node)" | tee -a "$REPORT"
+      continue
+    fi
+
+    # Use a clean PATH so $NODE_BIN wins. Append a safe baseline for utilities.
+    SAFE_PATH="$NODE_BIN:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+    echo "==================================="
+    echo "Node $NV / pnpm $PV"
+    echo "==================================="
+
+    PATH="$SAFE_PATH" node --version
+
+    # Install the requested pnpm into this Node's tree so it's the one PATH finds.
+    # --prefix avoids the global npm prefix shared across Node installs.
+    PREFIX="$HOME/node-versions/_pnpm-cache/$NV"
+    mkdir -p "$PREFIX"
+    PATH="$SAFE_PATH" npm install --silent --prefix "$PREFIX" "pnpm@$PV" >/dev/null 2>&1
+    PNPM_BIN="$PREFIX/node_modules/.bin"
+
+    PATH="$PNPM_BIN:$SAFE_PATH" pnpm --version
+    PATH="$PNPM_BIN:$SAFE_PATH" pnpm test 2>&1 | tail -6
+    RC=$?
+    if [ $RC -eq 0 ]; then
+      echo "node$NV/pnpm$PV: PASS" >> "$REPORT"
+    else
+      echo "node$NV/pnpm$PV: FAIL (exit $RC)" >> "$REPORT"
+    fi
+  done
+done
+
+echo
+echo "=========== SUMMARY ==========="
+cat "$REPORT"

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,25 @@
+type LoggerLike = {
+  info: (...args: unknown[]) => void
+  warn: (...args: unknown[]) => void
+  error: (...args: unknown[]) => void
+  debug: (...args: unknown[]) => void
+  trace: (...args: unknown[]) => void
+  fatal: (...args: unknown[]) => void
+  mark: (...args: unknown[]) => void
+}
+
+const noop = (..._args: unknown[]) => {}
+
+const stubLogger: LoggerLike = {
+  info: noop,
+  warn: noop,
+  error: noop,
+  debug: noop,
+  trace: noop,
+  fatal: noop,
+  mark: noop,
+}
+
+const g = globalThis as Record<string, unknown>
+if (!g.logger) g.logger = stubLogger
+if (!g.debug) g.debug = () => noop

--- a/tests/verify-create-karin-deep.sh
+++ b/tests/verify-create-karin-deep.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Deeper smoke test: run `create-karin -y` in a temp dir on Node 24/25/26.
+# This exercises template copying, fs ops, prompts default path, registry probe,
+# and the initial pnpm install — failures here are what real users would see.
+# Timeout 90s; if it hangs in pnpm install we'll see partial logs anyway.
+set -uo pipefail
+
+cd /mnt/d/Github/Karin-test-build
+CLI="$(pwd)/packages/create-karin/dist/index.mjs"
+
+declare -A NODES=(
+  ["24"]="$HOME/node-versions/v24.15.0/bin/node"
+  ["25"]="$HOME/node-versions/v25.9.0/bin/node"
+  ["26"]="$HOME/node-versions/v26.1.0/bin/node"
+)
+
+REPORT="/tmp/karin-create-deep.txt"
+: > "$REPORT"
+
+for NV in 24 25 26; do
+  N="${NODES[$NV]}"
+  if [ ! -x "$N" ]; then
+    echo "node $NV: SKIP" | tee -a "$REPORT"
+    continue
+  fi
+
+  TMPDIR=$(mktemp -d /tmp/karin-deep-XXXXXX)
+  echo "================================="
+  echo "Node $NV — $TMPDIR"
+  echo "================================="
+
+  cd "$TMPDIR"
+  set +e
+  timeout 120 "$N" "$CLI" -y 2>&1 | tail -50
+  RC=${PIPESTATUS[0]}
+  set -e
+  echo "--- exit=$RC ---"
+
+  # Inspect what was created
+  echo "--- created files ---"
+  ls -la "$TMPDIR" | head -20
+
+  if [ $RC -eq 0 ]; then
+    echo "node$NV: PASS (rc=0)" >> "$REPORT"
+  elif [ $RC -eq 124 ]; then
+    echo "node$NV: TIMEOUT (likely got past scaffold into pnpm install)" >> "$REPORT"
+  else
+    echo "node$NV: FAIL (exit $RC)" >> "$REPORT"
+  fi
+
+  cd /
+  rm -rf "$TMPDIR"
+done
+
+echo
+echo "=========== SUMMARY ==========="
+cat "$REPORT"

--- a/tests/verify-create-karin-published.sh
+++ b/tests/verify-create-karin-published.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Reproduce the *user-facing* `pnpm create karin` flow, which downloads the
+# published create-karin@latest from npm and runs it. This is the actual code
+# path real users hit — different from running our local dist/index.mjs.
+set -uo pipefail
+
+declare -A NODES=(
+  ["22"]="$HOME/node-versions/v22.22.2/bin/node"
+  ["24"]="$HOME/node-versions/v24.15.0/bin/node"
+  ["25"]="$HOME/node-versions/v25.9.0/bin/node"
+  ["26"]="$HOME/node-versions/v26.1.0/bin/node"
+)
+
+if [ ! -x "${NODES[22]}" ]; then
+  NODES[22]="$(which node)"
+fi
+
+REPORT="/tmp/karin-create-pub-report.txt"
+: > "$REPORT"
+
+for NV in 22 24 25 26; do
+  N="${NODES[$NV]}"
+  if [ ! -x "$N" ]; then
+    echo "node $NV: SKIP" | tee -a "$REPORT"
+    continue
+  fi
+
+  NODE_DIR="$(dirname "$N")"
+  # Use the pnpm binary that lives next to *this* node (so any wrappers resolve right)
+  PNPM_PREFIX="$HOME/node-versions/_pnpm-cache/$NV"
+  PNPM_BIN="$PNPM_PREFIX/node_modules/.bin/pnpm"
+  if [ ! -x "$PNPM_BIN" ]; then
+    echo "node $NV: SKIP (no pnpm at $PNPM_BIN — run run-matrix.sh first)" | tee -a "$REPORT"
+    continue
+  fi
+
+  TMPDIR="$(mktemp -d /tmp/karin-pub-test-XXXXXX)"
+  echo "================================="
+  echo "Node $NV ($N), pnpm: $("$N" "$PNPM_BIN" --version)"
+  echo "tmp: $TMPDIR"
+  echo "================================="
+
+  cd "$TMPDIR"
+
+  # `pnpm create karin --help` should fetch latest create-karin and run --help.
+  # If anything in the bundle blows up at import time on this Node version, this is where we see it.
+  set +e
+  OUT=$(timeout 90 env PATH="$NODE_DIR:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+        "$PNPM_BIN" create karin --help 2>&1)
+  RC=$?
+  set -e
+
+  echo "--- exit=$RC ---"
+  echo "$OUT"
+
+  if [ $RC -eq 0 ]; then
+    echo "node$NV: PASS" >> "$REPORT"
+  else
+    echo "node$NV: FAIL (exit $RC)" >> "$REPORT"
+  fi
+
+  cd /
+  rm -rf "$TMPDIR"
+done
+
+echo
+echo "=========== SUMMARY ==========="
+cat "$REPORT"

--- a/tests/verify-create-karin.sh
+++ b/tests/verify-create-karin.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Smoke-test the create-karin CLI on Node 22/24/25/26.
+# Strategy:
+#   1. Run --help (cheapest path; imports ora/prompts/kolorist/strip-json-comments)
+#   2. Run with stdin from /dev/null and a short timeout so we exercise the
+#      environment-detection code path (registry/pnpm/pm2 lookup) without
+#      blocking forever on the interactive prompt.
+set -uo pipefail
+
+cd /mnt/d/Github/Karin-test-build
+CLI=packages/create-karin/dist/index.mjs
+
+if [ ! -f "$CLI" ]; then
+  echo "ERROR: $CLI not found. Did you run pnpm build?"
+  exit 2
+fi
+
+declare -A NODES=(
+  ["22"]="$HOME/node-versions/v22.22.2/bin/node"
+  ["24"]="$HOME/node-versions/v24.15.0/bin/node"
+  ["25"]="$HOME/node-versions/v25.9.0/bin/node"
+  ["26"]="$HOME/node-versions/v26.1.0/bin/node"
+)
+
+if [ ! -x "${NODES[22]}" ]; then
+  NODES[22]="$(which node)"
+fi
+
+REPORT="/tmp/karin-create-report.txt"
+: > "$REPORT"
+
+for NV in 22 24 25 26; do
+  N="${NODES[$NV]}"
+  if [ ! -x "$N" ]; then
+    echo "node $NV: SKIP (binary not found at $N)" | tee -a "$REPORT"
+    continue
+  fi
+
+  echo "================================="
+  echo "Node $NV ($N)"
+  echo "================================="
+  "$N" --version
+
+  # --help: should exit 0 cleanly
+  HELP_OUT=$("$N" "$CLI" --help 2>&1)
+  HELP_RC=$?
+  echo "--- --help exit=$HELP_RC ---"
+  echo "$HELP_OUT"
+  if [ $HELP_RC -ne 0 ]; then
+    echo "node$NV: FAIL on --help (exit $HELP_RC)" >> "$REPORT"
+    continue
+  fi
+
+  # No-args run; we let it auto-detect and then bail when prompts cannot read
+  # stdin. Capture full stderr so we can see *what* breaks on each Node.
+  set +e
+  FULL_OUT=$(timeout 20 "$N" "$CLI" </dev/null 2>&1)
+  NO_ARGS_RC=$?
+  set -e
+  echo "--- no-args exit=$NO_ARGS_RC ---"
+  printf '%s\n' "$FULL_OUT"
+
+  # exit 124 = timed out at the interactive prompt → that's actually success
+  # because environment detection ran, we just stopped at prompts.
+  # Any other non-zero = real failure to investigate.
+  if [ $NO_ARGS_RC -eq 0 ] || [ $NO_ARGS_RC -eq 124 ] || [ $NO_ARGS_RC -eq 130 ]; then
+    echo "node$NV: PASS (rc=$NO_ARGS_RC)" >> "$REPORT"
+  else
+    echo "node$NV: FAIL on no-args (exit $NO_ARGS_RC)" >> "$REPORT"
+  fi
+done
+
+echo
+echo "=========== SUMMARY ==========="
+cat "$REPORT"

--- a/tests/verify-pnpm11.sh
+++ b/tests/verify-pnpm11.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# One-off: temporarily remove the `packageManager` pin so pnpm 11 actually
+# stays at v11 (instead of self-downgrading to the pinned version) and
+# verify install + tests still work.
+set -uo pipefail
+cd /mnt/d/Github/Karin-test-build
+
+NODE_BIN="$HOME/node-versions/v22.22.2/bin"
+[ -x "$NODE_BIN/node" ] || NODE_BIN="$(dirname "$(which node)")"
+export PATH="$HOME/node-versions/_pnpm-cache/22/node_modules/.bin:$NODE_BIN:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+cp package.json package.json.bak
+node -e "
+  const fs = require('fs');
+  const pkg = JSON.parse(fs.readFileSync('package.json','utf8'));
+  delete pkg.packageManager;
+  fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+"
+
+echo "pnpm version (no packageManager pin): $(pnpm --version)"
+pnpm test 2>&1 | tail -10
+RC=$?
+
+mv package.json.bak package.json
+exit $RC

--- a/tests/verify-pnpm9.sh
+++ b/tests/verify-pnpm9.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Sanity check: pnpm 9 can install this repo and run the unit tests.
+# Mirrors what the CI 'node22/pnpm9' cell will do.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+PNPM="$HOME/node-versions/_pnpm-cache/9/node_modules/.bin/pnpm"
+if [ ! -x "$PNPM" ]; then
+  echo "ERROR: pnpm 9 not installed at $PNPM"
+  exit 2
+fi
+
+echo "Using pnpm: $($PNPM --version)"
+echo "Using node: $(node --version)"
+
+"$PNPM" install --no-frozen-lockfile 2>&1 | tail -10
+RC=${PIPESTATUS[0]}
+if [ $RC -ne 0 ]; then
+  echo "pnpm 9 install FAILED (exit $RC)"
+  exit $RC
+fi
+
+"$PNPM" test 2>&1 | tail -15

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'packages/core/src'),
+    },
+  },
+  test: {
+    include: ['packages/**/tests/**/*.test.ts'],
+    exclude: ['**/node_modules/**', '**/dist/**'],
+    globals: false,
+    environment: 'node',
+    setupFiles: ['./tests/setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['packages/core/src/utils/**/*.ts'],
+      exclude: [
+        '**/*.d.ts',
+        'packages/core/src/utils/logger/**',
+        'packages/core/src/utils/debug/**',
+      ],
+    },
+  },
+})


### PR DESCRIPTION
## Summary

- **引擎升级**：所有 `engines.node` 从 `>=18` 升至 `>=22`；新增 `engines.pnpm: ">=9"` 覆盖 9/10/11；根 `package.json` 添加 `packageManager: "pnpm@10.14.0"` 锁定可复现安装版本；`@types/node` 升到 `^22.10.0`。
- **CI**：`pnpm/action-setup` 全部升到 v4 并改用 pnpm@10，发布相关 workflow 增加 `actions/setup-node@v4` 与 pnpm 缓存；新增 `.github/workflows/ci.yml`，对 Node 22/24/26 × pnpm 10/11 跑 `pnpm test` 矩阵。
- **单元测试**：根目录新增 `vitest.config.ts`（`@` 别名映射 `packages/core/src`，覆盖率聚焦 `utils/**`）；`tests/setup.ts` 注入 `logger`/`debug` 全局桩；`packages/core/tests/` 共 **108** 个用例，覆盖 `utils/common(number/sleep/string/uptime)`、`utils/system(time/range)`、`utils/fs(json/path)`、`utils/ini`、`utils/button/convert`。
- **WSL 验证脚本**：`tests/run-matrix.sh`（Node 22/24/26 × pnpm 10/11）、`tests/verify-pnpm11.sh`（临时摘掉 `packageManager` 钉子，验证 pnpm 11 自身真正能跑），`tests/check-pnpm-version.sh`（对比项目内外 pnpm 自版本切换）。

## 本地验证

在 WSL Ubuntu 24.04 下跑过 6 个组合，每组 108/108 全绿：

```
node22/pnpm10.14.0: PASS
node22/pnpm11.1.1:  PASS
node24/pnpm10.14.0: PASS
node24/pnpm11.1.1:  PASS
node26/pnpm10.14.0: PASS
node26/pnpm11.1.1:  PASS
```

另外 `verify-pnpm11.sh` 摘掉 `packageManager` 钉子后直接以 pnpm 11.1.1 跑，108/108 通过，确认 pnpm 11 本身能够真正驱动安装与测试。

## 已知遗留（未在本 PR 修复，仅由测试锁定当前行为）

- `packages/core/src/utils/system/time.ts` 的 `formatTime`：
  - 清零正则 `/0[天时分秒]/g` 漏掉 `0小时`（因为 `0` 后面是 `小` 不是 `时`），10 位秒级时间戳会被错误地放大成天级负数。
  - 测试用 `toBe('0小时钟5秒')` 等断言**锁定当前行为**，留待单独的 fix PR 处理。

## Test plan

- [ ] CI 矩阵在 PR 上首次跑出 6 组绿
- [ ] `pnpm install` 不再因 `engines` 报错
- [ ] `pnpm test` 在 Node 22/24/26 上均 108 用例通过
- [ ] release / beta-version / manual-publish-core 三个 workflow 在 Node 22 + pnpm 10 下仍能完成构建步骤

## Summary by Sourcery

将最低支持的 Node.js 版本提升到 22，使项目与 pnpm 9+ 以及锁定的 pnpm 10 工具链保持一致，并为核心工具引入基于 vitest 的测试套件，同时更新 CI 以在现代 Node/pnpm 组合下运行测试。

New Features:
- 添加 vitest 配置和测试初始化设置，将核心源代码通过别名 `'@'` 引入，并在测试中接入全局 logger/debug 的桩实现。
- 为核心工具模块引入单元测试，包括按钮转换、文件系统 JSON 工具、INI 处理以及其他通用/系统辅助方法。
- 添加辅助 shell 脚本，用于验证 Node/pnpm 版本矩阵以及 pnpm 11 在 WSL 下的行为。

Enhancements:
- 提升所有 package 的 engines 要求，使其需要 Node.js >=22 和 pnpm >=9，并在各个包中将 @types/node 更新为 Node 22 的类型定义。
- 将项目的 packageManager 固定为 `pnpm@10.14.0`，以确保本地和 CI 安装的可重现性。

CI:
- 新增 CI 工作流，在 Node 22/24/26 和 pnpm 10/11（对 Node 26 使用精简配对）上运行测试套件。
- 更新 release、beta-version 和 manual-publish-core 工作流，使其使用 pnpm/action-setup v4、pnpm 10、Node 22，以及支持 pnpm 的缓存机制。

Tests:
- 为核心工具新增基于 vitest 的测试矩阵，覆盖 common、system、filesystem、INI 和按钮转换等辅助方法，扩大自动化回归测试覆盖范围。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Raise the minimum supported Node.js version to 22, align the project with pnpm 9+ and a pinned pnpm 10 toolchain, and introduce a vitest-based test suite for core utilities, with CI updated to run the tests across modern Node/pnpm combinations.

New Features:
- Add a vitest configuration and test setup that aliases core source under '@' and wires in global logger/debug stubs for tests.
- Introduce unit tests for core utility modules, including button conversion, filesystem JSON utilities, INI handling, and other common/system helpers.
- Add helper shell scripts to validate Node/pnpm version matrices and pnpm 11 behavior under WSL.

Enhancements:
- Bump all package engines to require Node.js >=22 and pnpm >=9, and update @types/node to the Node 22 typings across packages.
- Pin the project packageManager to pnpm@10.14.0 to ensure reproducible local and CI installations.

CI:
- Add a new CI workflow that runs the test suite across Node 22/24/26 and pnpm 10/11 (with a reduced pair for Node 26).
- Update release, beta-version, and manual-publish-core workflows to use pnpm/action-setup v4, pnpm 10, Node 22, and pnpm-aware caching.

Tests:
- Add a vitest-based test matrix for core utilities covering common, system, filesystem, INI, and button conversion helpers, expanding automated regression coverage.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised minimum Node.js requirement to 22 and added pnpm >=9; set packageManager to pnpm@10.14.0
  * Updated project workflows to use newer Node and pnpm tooling and enabled pnpm caching
  * Expanded CI to run additional build and smoke-check steps against multiple Node/pnpm combinations

* **Tests**
  * Added extensive Vitest suites covering many core utilities and filesystem/INI/path helpers
  * Added Vitest config and multiple test/verification scripts for cross-Node/pnpm validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KarinJS/Karin/pull/648)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->