### PR TITLE
fix: 优化获取web.config路径的逻辑，简化代码结构

### DIFF
--- a/packages/core/src/server/plugins/config/webConfig.ts
+++ b/packages/core/src/server/plugins/config/webConfig.ts
@@ -54,7 +54,7 @@ export const defaultWebConfig = (
 const getWebConfigPath = (plugin: PkgInfo) => {
   const pkg = plugin.pkgData
 
-  if (!pkg.karin) return null
+  if (!pkg?.karin) return null
 
   const getPath = (value?: string) => {
     if (!value) return null

--- a/packages/core/src/server/plugins/config/webConfig.ts
+++ b/packages/core/src/server/plugins/config/webConfig.ts
@@ -57,7 +57,7 @@ const getWebConfigPath = (plugin: PkgInfo) => {
   if (!pkg?.karin) return null
 
   const getPath = (value?: string) => {
-    if (!value) return null
+    if (typeof value !== 'string' || !value) return null
     const filepath = path.join(plugin.dir, value)
     return fs.existsSync(filepath) ? filepath : null
   }

--- a/packages/core/src/server/plugins/config/webConfig.ts
+++ b/packages/core/src/server/plugins/config/webConfig.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { isDev } from '@/env'
+import { isDev, isTs } from '@/env'
 import { imports } from '@/utils'
 import { getPlugins } from '@/plugin/system/list'
 import type { Icon, PkgInfo, PluginAdminListResponse } from '@/types'
@@ -52,21 +52,28 @@ export const defaultWebConfig = (
  * 获取web.config文件绝对路径
  */
 const getWebConfigPath = (plugin: PkgInfo) => {
-  const dev = isDev()
   const pkg = plugin.pkgData
 
-  if (!pkg.karin?.web) return null
+  if (!pkg.karin) return null
 
-  if (dev) {
-    if (!pkg.karin['ts-web']) return null
-    const filepath = path.join(plugin.dir, pkg.karin['ts-web'])
-    if (!fs.existsSync(filepath)) return null
-    return filepath
+  const getPath = (value?: string) => {
+    if (!value) return null
+    const filepath = path.join(plugin.dir, value)
+    return fs.existsSync(filepath) ? filepath : null
   }
 
-  const filepath = path.join(plugin.dir, pkg.karin.web)
-  if (!fs.existsSync(filepath)) return null
-  return filepath
+  /** npm插件处于安装态，即使开发环境也应读取发布产物 */
+  if (plugin.type === 'npm' || plugin.dir.includes('node_modules')) {
+    return getPath(pkg.karin.web)
+  }
+
+  /** 本地源码插件在TS运行时优先读取ts-web */
+  if (isTs()) {
+    const filepath = getPath(pkg.karin['ts-web'])
+    if (filepath) return filepath
+  }
+
+  return getPath(pkg.karin.web)
 }
 
 /**


### PR DESCRIPTION
## Summary by Sourcery

调整 `web.config` 路径解析，以更好地处理不同的插件类型和运行环境，同时简化查找逻辑。

**Bug 修复：**
- 确保基于 `npm` 和 `node_modules` 的插件在开发环境中也始终使用已发布的 `web.config` 输出，避免错误地解析到 `ts-web` 配置。
- 对本地 TypeScript 运行时插件，在可用时优先使用 `ts-web` 配置，并在必要时回退到编译后的 `web.config`。

**改进：**
- 将 `web.config` 路径计算重构为可复用的辅助方法，以获得更清晰的结构并减少重复代码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust web.config path resolution to better handle different plugin types and runtime environments while simplifying the lookup logic.

Bug Fixes:
- Ensure npm and node_modules-based plugins always use the published web config output even in development, avoiding incorrect ts-web resolution.
- Prefer ts-web config for local TypeScript runtime plugins when available, falling back to the compiled web config when necessary.

Enhancements:
- Refactor web.config path computation into a reusable helper for cleaner structure and reduced duplication.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the app locates and loads web configuration for different plugin setups.
  * Fixed fallback behavior so local development and packaged plugins use the most appropriate configuration automatically.
  * Plugins without web configuration are now safely ignored instead of causing lookup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->