### PR TITLE
fix: web配置组件，手风琴子项内部分配置组件无法正常渲染嵌套字段

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -198,5 +198,5 @@
     "access": "public",
     "registry": "https://registry.npmjs.org"
   },
-  "time": "2026-06-28T02:07:01.215Z"
+  "time": "2026-07-07T03:26:08.299Z"
 }

--- a/packages/web/src/components/config/plugin/render.tsx
+++ b/packages/web/src/components/config/plugin/render.tsx
@@ -51,7 +51,7 @@ export const RenderComponent: React.FC<{
       }
 
       if (option.componentType === 'switch') {
-        list.push(createSwitch(option, register))
+        list.push(createSwitch(option, control, basePath))
         return
       }
 

--- a/packages/web/src/components/heroui/switchs.tsx
+++ b/packages/web/src/components/heroui/switchs.tsx
@@ -1,19 +1,22 @@
 import { Switch as HeroSwitch } from '@heroui/switch'
 import { cn } from '@/lib/utils'
+import { Controller } from 'react-hook-form'
 import type { JSX } from 'react'
 import type { SwitchProps } from 'node-karin'
-import type { FormRegister } from '../config/plugin/render'
+import type { FormControl } from '../config/plugin/render'
 import { useState } from 'react'
 
 /**
  * 渲染开关组件
  * @param props - 输入框属性
- * @param register - 表单注册器
+ * @param control - 表单控制器
+ * @param basePath - 基础路径
  * @returns 渲染后的输入框组件
  */
 export const createSwitch = (
   props: SwitchProps,
-  register: FormRegister
+  control: FormControl,
+  basePath?: string
 ): JSX.Element => {
   const {
     componentType: _,
@@ -25,6 +28,7 @@ export const createSwitch = (
     ...options
   } = props
 
+  const name = basePath ? `${basePath}.${key}.value` : `${key}.value`
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
 
   const handleContainerClick = (e: React.MouseEvent) => {
@@ -32,7 +36,9 @@ export const createSwitch = (
     if (isDisabled) return
     // 如果点击的是描述区域，不触发开关切换
     if ((e.target as HTMLElement).closest('.description-area')) return
-    const switchElement = document.querySelector(`[data-switch-key="${key}"]`) as HTMLElement
+    // 如果点击的是开关本体，交给开关组件自己处理，避免重复切换
+    if ((e.target as HTMLElement).closest('.switch-control-area')) return
+    const switchElement = document.querySelector(`[data-switch-key="${name}"]`) as HTMLElement
     switchElement?.click()
   }
 
@@ -93,19 +99,29 @@ export const createSwitch = (
         </div>
 
         {/* 开关控件位于右侧中间 */}
-        <div className='absolute right-3 top-1/2 -translate-y-1/2 sm:right-4'>
-          <HeroSwitch
-            key={key}
-            {...options}
-            isDisabled={isDisabled}
-            data-switch-key={key}
-            className={cn(
-              isDisabled ? 'cursor-not-allowed' : 'cursor-pointer',
-              `data-[selected=true]:border-${options.color || 'primary'}`,
-              componentClassName
+        <div className='switch-control-area absolute right-3 top-1/2 -translate-y-1/2 sm:right-4'>
+          <Controller
+            name={name}
+            control={control}
+            defaultValue={(defaultSelected ?? false) as never}
+            render={({ field: { value, onChange, onBlur, name, ref } }) => (
+              <HeroSwitch
+                key={key}
+                {...options}
+                isDisabled={isDisabled}
+                data-switch-key={name}
+                className={cn(
+                  isDisabled ? 'cursor-not-allowed' : 'cursor-pointer',
+                  `data-[selected=true]:border-${options.color || 'primary'}`,
+                  componentClassName
+                )}
+                isSelected={(value as unknown) === true}
+                onValueChange={onChange}
+                onBlur={onBlur}
+                name={name}
+                ref={ref}
+              />
             )}
-            defaultSelected={defaultSelected ?? false}
-            {...register(`${key}.value`)}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary by Sourcery

将 Web 开关配置组件与 react-hook-form 的 control 集成，以支持嵌套字段路径，并在复杂布局中实现正确的点击处理。

Bug 修复：
- 通过使用带有基础路径感知字段名的 react-hook-form `Controller`，修复嵌套或手风琴式配置项中的开关字段无法正确渲染或绑定的问题。
- 通过将容器点击处理限制在专用控制区域内，防止在直接点击开关时出现重复切换行为。

增强：
- 更新开关组件的集成方式，从使用 `register` 改为使用表单 `control`，以便在处理嵌套值时实现更灵活的表单状态管理。

构建：
- 更新核心包元数据的时间戳。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate the web switch configuration component with react-hook-form control to support nested field paths and correct click handling in complex layouts.

Bug Fixes:
- Fix switch fields inside nested or accordion configuration items not rendering or binding correctly by using react-hook-form Controller with base path-aware field names.
- Prevent duplicate toggle behavior when clicking directly on the switch by scoping container click handling to a dedicated control area.

Enhancements:
- Update switch component integration to use form control instead of register for more flexible form state management with nested values.

Build:
- Update core package metadata timestamp.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved switch controls so they stay correctly in sync with form state, including within nested configuration sections.
  * Fixed switch interactions to respond more reliably when toggled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->