### PR TITLE
fix: 修复获取所有bot列表接口返回Bot数量的问题

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -198,5 +198,5 @@
     "access": "public",
     "registry": "https://registry.npmjs.org"
   },
-  "time": "2026-07-07T03:26:08.299Z"
+  "time": "2026-07-19T11:36:33.086Z"
 }

--- a/packages/core/src/server/system/botList.ts
+++ b/packages/core/src/server/system/botList.ts
@@ -9,7 +9,8 @@ import type { RequestHandler } from 'express'
 export const getBotsRouter: RequestHandler = async (_, res) => {
   const bots = getAllBotList().map(bot => ({
     index: bot.index,
-    selfId: bot.bot.selfId,
+    account: bot.bot.account,
+    adapter: bot.bot.adapter,
   }))
   createSuccessResponse(res, bots)
 }

--- a/packages/core/src/server/system/botList.ts
+++ b/packages/core/src/server/system/botList.ts
@@ -1,4 +1,4 @@
-import { getBotCount } from '@/service/bot'
+import { getAllBotList } from '@/service/bot'
 import { createSuccessResponse } from '@/server/utils/response'
 
 import type { RequestHandler } from 'express'
@@ -7,5 +7,5 @@ import type { RequestHandler } from 'express'
  * 获取所有bot列表
  */
 export const getBotsRouter: RequestHandler = async (_, res) => {
-  createSuccessResponse(res, getBotCount())
+  createSuccessResponse(res, getAllBotList())
 }

--- a/packages/core/src/server/system/botList.ts
+++ b/packages/core/src/server/system/botList.ts
@@ -7,5 +7,9 @@ import type { RequestHandler } from 'express'
  * 获取所有bot列表
  */
 export const getBotsRouter: RequestHandler = async (_, res) => {
-  createSuccessResponse(res, getAllBotList())
+  const bots = getAllBotList().map(bot => ({
+    index: bot.index,
+    selfId: bot.bot.selfId,
+  }))
+  createSuccessResponse(res, bots)
 }

--- a/packages/web/src/pages/dashboard/index.tsx
+++ b/packages/web/src/pages/dashboard/index.tsx
@@ -215,7 +215,7 @@ function Status ({ statusData, statusError, onGlobalUpdateStart, onGlobalUpdateE
   const error = statusError
 
   const localPluginsList = useRequest(() => request.serverPost<LocalApiResponse[], {}>('/api/v1/plugin/local'))
-  const botList = useRequest(() => request.serverGet<number>('/api/v1/system/get/bots'), {
+  const botList = useRequest(() => request.serverGet<Array<Object>>('/api/v1/system/get/bots'), {
     pollingInterval: 5000,
   })
 
@@ -344,7 +344,7 @@ function Status ({ statusData, statusError, onGlobalUpdateStart, onGlobalUpdateE
         <MemoizedStatusItem title='PID' value={data.pid} />
         <MemoizedStatusItem title='PM2 ID' value={data.pm2_id} />
         <MemoizedStatusItem title='插件数量' value={localPluginsList.data?.length || '--'} />
-        <MemoizedStatusItem title='适配器数量' value={botList.data} />
+        <MemoizedStatusItem title='适配器数量' value={botList.data?.length || 0} />
         <MemoizedStatusItem
           title='版本'
           value={versionCardValue}

--- a/packages/web/src/pages/dashboard/index.tsx
+++ b/packages/web/src/pages/dashboard/index.tsx
@@ -681,7 +681,7 @@ function StatusItem ({ title, value }: StatusItemProps) {
           <IconComponent className='w-4 h-4 lg:w-5 lg:h-5 text-primary' />
           <p className='text-sm text-primary select-none'>{title}</p>
         </div>
-        <div className='mt-1 md:mt-2 lg:mt-3 text-lg md:text-xl lg:text-2xl text-default-800 font-medium w-full'>{value || '--'}</div>
+        <div className='mt-1 md:mt-2 lg:mt-3 text-lg md:text-xl lg:text-2xl text-default-800 font-medium w-full'>{value ?? '--'}</div>
       </CardHeader>
     </Card>
   )


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 修复 `getBotsRouter` 处理程序，使其返回所有机器人，而不仅仅是机器人数量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the getBotsRouter handler to return all bots rather than only the bot count.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bot listing endpoint to return and display the full set of available bots (with index, account, and adapter details) instead of only a total count.
  * Refreshed the dashboard status display so the adapter count card now reflects the number of returned bots (defaulting to 0 when unavailable).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->