### PR TITLE
fix(core): support SnowLuma message reactions

### DIFF
--- a/packages/core/src/adapter/onebot/core/core.ts
+++ b/packages/core/src/adapter/onebot/core/core.ts
@@ -867,7 +867,7 @@ export class AdapterOneBot<T extends OneBotType> extends AdapterBase {
       return
     }
 
-    if (this.adapter.name === 'NapCat.Onebot') {
+    if (this.adapter.name === 'NapCat.Onebot' || this.adapter.name === 'SnowLuma') {
       await this._onebot.nc_setMsgEmojiLike(+messageId, faceId + '', isSet)
       return
     }


### PR DESCRIPTION
## Summary
- route SnowLuma message reactions through the existing `set_msg_emoji_like` OneBot action
- keep the existing NapCat behavior unchanged

SnowLuma implements `set_msg_emoji_like` with the same `message_id`, `emoji_id`, and `set` parameters used by the existing NapCat branch.

## Verification
- `pnpm --filter @karinjs/onebot run build`
- `pnpm --filter node-karin run build`

## Summary by Sourcery

错误修复：
- 确保 SnowLuma 适配器能够通过 `set_msg_emoji_like` 操作正确处理消息表情回应请求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure SnowLuma adapters correctly process message reaction requests via the set_msg_emoji_like action.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled message emoji and like reactions for SnowLuma through the appropriate reaction handling path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->