### PR TITLE
fix(core): skip node forward options for SnowLuma

### DIFF
--- a/packages/core/src/adapter/onebot/core/core.ts
+++ b/packages/core/src/adapter/onebot/core/core.ts
@@ -1096,7 +1096,7 @@ export class AdapterOneBot<T extends OneBotType> extends AdapterBase {
           if (elem.options.source) node.data.source = elem.options.source
         }
 
-        if (options && messages.length === 0) {
+        if (this.adapter.name !== 'SnowLuma' && options && messages.length === 0) {
           node.data.news = options.news
           node.data.prompt = options.prompt
           node.data.summary = options.summary


### PR DESCRIPTION
## 问题

SnowLuma 会拒绝合并转发首个 node 中的 `news` 数组，并返回 `forward messages[0].news must be a scalar value`。

## 修复

仅在适配器名称为 `SnowLuma` 时，不再将顶层 `ForwardOptions` 冗余写入首个转发 node；顶层 API 参数仍会照常传递。其他 OneBot 适配器保持原有行为。

## 验证

- `pnpm --filter @karinjs/onebot run build`
- `pnpm build:core`

## Summary by Sourcery

错误修复：
- 防止 SnowLuma 因首个转发节点中的 `news` 值为非标量而拒绝已合并的转发消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent SnowLuma from rejecting merged forward messages due to non-scalar `news` values in the first forward node.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated forwarded-message metadata handling for the SnowLuma adapter.
  * Prevented top-level card fields from being added to the first forwarded message when using SnowLuma.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->