### PR TITLE
feat: 更新构建配置，迁移至 tsdown，调整输出目录至 dist

### DIFF
--- a/packages/cli-Internal/src/init.ts
+++ b/packages/cli-Internal/src/init.ts
@@ -32,6 +32,7 @@ const getIsDev = (dir: string) => {
     'eslint.config.js',
     '.prettierrc',
     'vite.config.ts',
+    'tsdown.config.ts',
     'tsup.config.ts',
   ]
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -198,5 +198,5 @@
     "access": "public",
     "registry": "https://registry.npmjs.org"
   },
-  "time": "2026-07-19T11:36:33.086Z"
+  "time": "2026-08-06T03:15:34.998Z"
 }

--- a/packages/karin-plugin-ts/.github/workflows/release.yml
+++ b/packages/karin-plugin-ts/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
       # 设置 Node.js 环境
       - uses: actions/setup-node@v4
         with:
-          # 设置 Node.js 版本
-          node-version: 20
+          # 设置 Node.js 版本（tsdown 构建要求 >= 22.18）
+          node-version: 22
           # 设置 npm 注册表 URL
           registry-url: https://registry.npmjs.org
         if: ${{ steps.release.outputs.release_created }}

--- a/packages/karin-plugin-ts/.gitignore
+++ b/packages/karin-plugin-ts/.gitignore
@@ -19,7 +19,7 @@ lerna-debug.log*
 /temp/
 
 # 配置
-/lib
+/dist
 
 # 依赖
 node_modules/

--- a/packages/karin-plugin-ts/package.json
+++ b/packages/karin-plugin-ts/package.json
@@ -13,12 +13,12 @@
     "url": "git+https://github.com/KarinJS/karin.git"
   },
   "scripts": {
-    "app": "node lib/app.js",
-    "build": "tsup",
+    "app": "node dist/app.js",
+    "build": "tsdown",
     "dev": "cross-env EBV_FILE=\"development.env\" node --import tsx src/app.ts",
     "pub": "npm publish --access public"
   },
-  "main": "lib/index.js",
+  "main": "dist/index.js",
   "devDependencies": {
     "@types/express": "^5.0.1",
     "@types/lodash": "^4.17.16",
@@ -27,14 +27,14 @@
     "eslint": "^9.7.0",
     "neostandard": "^0.11.9",
     "node-karin": "workspace:*",
-    "tsup": "^8.5.0",
+    "tsdown": "^0.22.2",
     "tsx": "^4.19.2",
     "typescript": "^5.5.3"
   },
   "karin": {
     "main": "src/index.ts",
     "apps": [
-      "lib/apps"
+      "dist/apps"
     ],
     "ts-apps": [
       "src/apps"
@@ -49,11 +49,11 @@
     ]
   },
   "files": [
-    "/lib/**/*.js",
-    "/lib/**/*.d.ts",
+    "/dist/**/*.js",
+    "/dist/**/*.d.ts",
     "/config/*.json",
     "resources",
-    "!lib/app.js",
+    "!dist/app.js",
     "LICENSE"
   ],
   "publishConfig": {

--- a/packages/karin-plugin-ts/tsconfig.json
+++ b/packages/karin-plugin-ts/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES2022",
     "esModuleInterop": true,
     "moduleResolution": "Bundler",
-    "outDir": "./lib",
+    "outDir": "./dist",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "paths": {

--- a/packages/karin-plugin-ts/tsdown.config.ts
+++ b/packages/karin-plugin-ts/tsdown.config.ts
@@ -1,24 +1,31 @@
-import { defineConfig } from 'tsup'
-import type { Options } from 'tsup'
+import { defineConfig } from 'tsdown'
+import type { UserConfig } from 'tsdown'
 
 /**
- * @description `tsup` configuration options
+ * @description `tsdown` configuration options
  */
-export const options: Options = {
+export const options: UserConfig = {
   entry: ['src/*.ts', 'src/apps/*.ts'], // 入口文件
   format: ['esm'], // 输出格式
   target: 'node18', // 目标环境
-  splitting: true, // 是否拆分文件 启用哦 不然会强制打包的~
   sourcemap: false, // 是否生成 sourcemap
   clean: true, // 是否清理输出目录
   dts: false, // 是否生成 .d.ts 文件 没啥事可以不需要生成类型，除非你的插件会被其他插件调用。
-  outDir: 'lib', // 输出目录
+  outDir: 'dist', // 输出目录
   treeshake: false, // 树摇优化
   minify: false, // 压缩代码
-  external: [
-    'node-karin',
-  ],
+  deps: {
+    neverBundle: [
+      'node-karin',
+      /^node-karin\//,
+    ],
+  },
   shims: true,
+  outExtensions () {
+    return {
+      js: '.js',
+    }
+  },
 }
 
 export default defineConfig(options)


### PR DESCRIPTION
## Summary by Sourcery

将 `karin-plugin-ts` 包的构建系统从 tsup 迁移到 tsdown，并将编译后的输出目录统一为 `dist`。

Build:
- 用 tsdown 配置替换 tsup 配置，包括更新入口、依赖打包方式以及输出设置。
- 更新 `karin-plugin-ts` 的 npm 脚本、主入口、TypeScript 的 `outDir`，以及发布文件的匹配模式，使其使用 `dist` 目录而不是 `lib`。
- 调整 CLI 的开发环境检测逻辑，使其在识别 `tsup.config.ts` 的同时，也能识别 `tsdown.config.ts`。

CI:
- 将发布工作流中的 Node.js 版本更新为 22，以满足 tsdown 的构建要求。

Chores:
- 刷新核心包元数据的时间戳。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate the karin-plugin-ts package build system from tsup to tsdown and standardize compiled output to the dist directory.

Build:
- Replace tsup configuration with tsdown configuration, including updated entry, dependency bundling, and output settings.
- Update karin-plugin-ts npm scripts, main entry, TypeScript outDir, and published file patterns to use the dist directory instead of lib.
- Adjust CLI dev-environment detection to recognize tsdown.config.ts alongside tsup.config.ts.

CI:
- Update the release workflow Node.js version to 22 to satisfy tsdown build requirements.

Chores:
- Refresh the core package metadata timestamp.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Compatibility**
  * Migrated the plugin build process to tsdown.
  * Build artifacts are now generated in the `dist` directory.
  * Improved handling of external runtime dependencies during builds.
  * Updated release automation to use Node.js 22, matching the current build requirements.
* **Developer Experience**
  * Projects using `tsdown.config.ts` are now correctly recognized as development projects.
  * Updated generated package paths and publishing settings to reflect the new output directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->