### PR TITLE
fix: 修复pnpmv11版本下脚本无法使用的问题

### DIFF
--- a/packages/create-karin/src/project.ts
+++ b/packages/create-karin/src/project.ts
@@ -37,6 +37,14 @@ export const createProject = async (
   spinner.succeed(green(`✨ node-karin@${karinVersion} 安装成功`))
 
   spinner.start('正在执行初始化...')
+  const content = fs.readFileSync(path.join(dir, 'package.json'), 'utf-8')
+  const pkg = JSON.parse(content)
+  if (pkg.devEngines) {
+    delete pkg.devEngines
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(pkg, null, 2))
+    console.log('检测到package.json包含 devEngines 字段,已移除')
+  }
+
   await exec('npx karin init', { cwd: dir })
   setAuthKey(dir, httpAuthKey, wsAuthKey)
   spinner.succeed(green('✨ 初始化完成'))

--- a/packages/create-karin/src/utils/exec.ts
+++ b/packages/create-karin/src/utils/exec.ts
@@ -40,6 +40,9 @@ export const exec = (
       if (typeof stdout !== 'string') {
         stdout = String(stdout)
       }
+      if (typeof stderr !== 'string') {
+        stderr = String(stderr)
+      }
       resolve({ status, error, stdout, stderr })
     })
   })


### PR DESCRIPTION
## Summary by Sourcery

通过清理不兼容的 `package.json` 字段，并增强命令执行输出的处理方式，确保项目初始化在较新的 pnpm 版本下正常工作。

Bug 修复：
- 在项目创建过程中，从生成的 `package.json` 中移除 `devEngines` 字段，以避免 pnpm v11 在执行脚本时出现问题。
- 在 `exec` 工具中将 `stderr` 统一规范为字符串类型，防止在消费命令输出时因类型问题导致的故障。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure project initialization works under newer pnpm by cleaning incompatible package.json fields and making exec output handling more robust.

Bug Fixes:
- Remove devEngines from generated package.json during project creation to avoid pnpm v11 script execution issues.
- Normalize stderr to a string in the exec utility to prevent type-related failures when consuming command output.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project setup by removing unsupported development engine settings after installing dependencies.
  * Improved command output handling so error messages are consistently displayed as text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->